### PR TITLE
fix(ci): repair Supabase migration history drift in preview

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -45,12 +45,34 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}"
-          # retry push to tolerate transient network hiccups
-          n=0
-          until [ $n -ge 3 ]; do
-            supabase db push && break
-            n=$((n+1)); echo "retry $n/3"; sleep 5
+
+          # Repair migration history to handle preview drift
+          # This marks phantom migrations as reverted so db push can proceed
+          echo "Checking for migration history drift..."
+          supabase migration list 2>&1 | grep -E "^[0-9]+" | while read migration_id rest; do
+            if [ ! -f "supabase/migrations/${migration_id}"*.sql ]; then
+              echo "Repairing phantom migration: $migration_id"
+              supabase migration repair --status reverted "$migration_id" || true
+            fi
           done
+
+          # Push migrations with proper failure handling
+          echo "Pushing migrations..."
+          push_success=false
+          for attempt in 1 2 3; do
+            if supabase db push 2>&1; then
+              echo "Migration push succeeded on attempt $attempt"
+              push_success=true
+              break
+            fi
+            echo "Push attempt $attempt failed, retrying..."
+            sleep 5
+          done
+
+          if [ "$push_success" = "false" ]; then
+            echo "ERROR: Migration push failed after 3 attempts"
+            exit 1
+          fi
 
       - name: Run admin RPCs (backfill → score loop → refresh)
         env:


### PR DESCRIPTION
## Summary

Fixes Supabase Preview CI failures caused by migration history drift.

### Root Cause

```
Remote migration versions not found in local migrations directory.
supabase migration repair --status reverted 20251022
```

Preview environment has migration `20251022` in history but file doesn't exist locally, causing `supabase db push` to fail silently.

### Fix

1. **Detect phantom migrations**: Check each migration ID against local files
2. **Repair automatically**: Mark missing migrations as reverted
3. **Proper failure handling**: Exit with error code 1 if push fails (previously silent)

### Testing

This will be verified when merged - the E2E CI Pipeline should now:
1. Repair any phantom migrations
2. Push new migrations successfully
3. Run admin RPCs without column errors

---

🤖 Generated with [Claude Code](https://claude.ai/code) - Final release fix