### PR TITLE
chore(ci): upgrade deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage/lcov.info
           flags: unittests
@@ -208,7 +208,7 @@ jobs:
         run: npm run build --workspace=apps/${{ matrix.app }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.app }}-build
           path: apps/${{ matrix.app }}/dist/
@@ -232,7 +232,7 @@ jobs:
           output: "trivy-results.sarif"
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
 
@@ -293,7 +293,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload E2E test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: e2e-test-results


### PR DESCRIPTION
## Summary
- Upgrade `actions/upload-artifact` from v3 to v4 (2 instances: build + e2e jobs)
- Upgrade `codecov/codecov-action` from v3 to v4 (legacy-tests job)
- Upgrade `github/codeql-action/upload-sarif` from v2 to v3 (security job)

## Motivation
All 5 build matrix entries fail at "Set up job" because GitHub has deprecated `actions/upload-artifact@v3`.
See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Proof: CI Run #21517533597 (PR #55) — all build jobs fail with:
```
##[error]This request has been automatically failed because it uses a
deprecated version of `actions/upload-artifact: v3`.
```

## Changes
- `actions/upload-artifact@v3` → `@v4` (build job, line 211)
- `actions/upload-artifact@v3` → `@v4` (e2e job, line 296)
- `codecov/codecov-action@v3` → `@v4` (legacy-tests job, line 180)
- `github/codeql-action/upload-sarif@v2` → `@v3` (security job, line 235)

## Test plan
- [ ] CI build jobs no longer fail at deprecated action version check
- [ ] Codecov upload still functions in legacy-tests job
- [ ] SARIF upload still functions in security scan job

🤖 Generated with [Claude Code](https://claude.com/claude-code)