### PR TITLE
fix(ci): use environment secrets in supabase-migrate [STAGING-TRUTH-007]

### DIFF
--- a/.github/workflows/supabase-migrate.yml
+++ b/.github/workflows/supabase-migrate.yml
@@ -40,9 +40,9 @@ jobs:
           cache: "npm"
 
       - name: Mask secrets
+        # SPRINT-007: Use environment secrets directly
         run: |
-          echo "::add-mask::${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING }}"
-          echo "::add-mask::${{ secrets.SUPABASE_SERVICE_ROLE_KEY_PROD }}"
+          echo "::add-mask::${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}"
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
@@ -51,16 +51,12 @@ jobs:
 
       - name: Set environment variables
         id: env
+        # SPRINT-007: Use environment secrets directly - workflow already uses
+        # `environment: ${{ inputs.environment }}` so secrets resolve per-env
         run: |
-          if [ "${{ inputs.environment }}" == "staging" ]; then
-            echo "SUPABASE_URL=${{ secrets.SUPABASE_URL_STAGING }}" >> $GITHUB_OUTPUT
-            echo "SUPABASE_SERVICE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING }}" >> $GITHUB_OUTPUT
-            echo "SUPABASE_PROJECT_REF=${{ secrets.SUPABASE_PROJECT_REF_STAGING }}" >> $GITHUB_OUTPUT
-          else
-            echo "SUPABASE_URL=${{ secrets.SUPABASE_URL_PROD }}" >> $GITHUB_OUTPUT
-            echo "SUPABASE_SERVICE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY_PROD }}" >> $GITHUB_OUTPUT
-            echo "SUPABASE_PROJECT_REF=${{ secrets.SUPABASE_PROJECT_REF_PROD }}" >> $GITHUB_OUTPUT
-          fi
+          echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> $GITHUB_OUTPUT
+          echo "SUPABASE_SERVICE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" >> $GITHUB_OUTPUT
+          echo "SUPABASE_PROJECT_REF=${{ secrets.SUPABASE_PROJECT_REF }}" >> $GITHUB_OUTPUT
 
       - name: Link Supabase project
         run: |


### PR DESCRIPTION
## Summary
- Fix secret naming mismatch in `supabase-migrate.yml`
- Workflow expects `_STAGING` suffix but environment secrets don't have it
- Since workflow uses `environment: ${{ inputs.environment }}`, secrets resolve per-env automatically

## Changes
- Changed `secrets.SUPABASE_URL_STAGING` → `secrets.SUPABASE_URL`
- Changed `secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING` → `secrets.SUPABASE_SERVICE_ROLE_KEY`
- Changed `secrets.SUPABASE_PROJECT_REF_STAGING` → `secrets.SUPABASE_PROJECT_REF`

## Sprint Reference
STAGING-TRUTH-DISCOVERY-007 - Proof artifacts in `out/sprints/STAGING-TRUTH-DISCOVERY-007/2026-02-28/`

## Next Steps
After merge, 006 can proceed:
1. Trigger `supabase-migrate.yml` for staging
2. Add `DISCORD_MODE` and `DISCORD_CANARY_WEBHOOK_URL` to staging env
3. Test canary publish endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)