### PR TITLE
fix(test): use vitest imports in canary-publish-one.test.ts

### DIFF
--- a/apps/api/test/unit/canary-publish-one.test.ts
+++ b/apps/api/test/unit/canary-publish-one.test.ts
@@ -4,7 +4,7 @@
  *
  * Tests for the POST /ops/canary/publish-one endpoint and publishOneToCanary helper.
  */
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from 'vitest';
 
 import type { CanaryPublishParams, CanaryPublishResult } from '../../src/lib/canaryPublisher';
 


### PR DESCRIPTION
## Summary
- Fix test import to use `vitest` instead of `@jest/globals`
- The API package uses vitest, not jest

## Test plan
- [x] Test passes with `npx vitest run test/unit/canary-publish-one.test.ts`
- [x] Type check passes
- [x] Pre-commit hooks pass

Sprint: STAGING-CREDENTIALS-TRUTH-LOCK-009

🤖 Generated with [Claude Code](https://claude.com/claude-code)