### PR TITLE
fix(ci): use SUPABASE_DB_PASSWORD for migrations

### DIFF
--- a/.github/workflows/supabase-migrate.yml
+++ b/.github/workflows/supabase-migrate.yml
@@ -119,7 +119,7 @@ jobs:
           echo "✅ Migration applied successfully"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ steps.env.outputs.SUPABASE_SERVICE_KEY }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       - name: Verify migration
         run: |


### PR DESCRIPTION
## Summary
- Fix migration workflow to use correct database password secret
- `SUPABASE_SERVICE_ROLE_KEY` is a JWT token for API auth, not the DB password
- Now uses dedicated `SUPABASE_DB_PASSWORD` secret

## Background
Migration workflow was failing with:
```
failed SASL auth (FATAL: password authentication failed for user "postgres")
```

The root cause was using the wrong credential type.

## Test plan
- [x] `SUPABASE_DB_PASSWORD` secret added to staging environment
- [ ] Re-run migration workflow after merge

Sprint: STAGING-CREDENTIALS-TRUTH-LOCK-009

🤖 Generated with [Claude Code](https://claude.com/claude-code)