### PR TITLE
fix(huly-os): operator CLI contract + incident truth [SPRINT-HULY-OPERATOR-CLI-FIX-015A]

### DIFF
--- a/tools/huly-os/daemon/drift-rules.ts
+++ b/tools/huly-os/daemon/drift-rules.ts
@@ -39,6 +39,16 @@ export function evaluateDrift(
   const prBranches = new Set(allPRs.map(pr => pr.headBranch));
   const prLinkedRefs = new Set(allPRs.flatMap(pr => pr.linkedIssueRefs));
 
+  // Build set of active sprint branches (those with open PRs).
+  // Stale branches (merged, no open PR) should not generate CI failure drift.
+  const activeBranches = new Set<string>();
+  for (const pr of openPRs) {
+    if (pr.headBranch.startsWith('sprint/')) {
+      activeBranches.add(pr.headBranch);
+    }
+  }
+  const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
   // Rule 1: PR_WITHOUT_ISSUE — open PR with no Huly issue ref
   for (const pr of openPRs) {
     if (pr.linkedIssueRefs.length === 0) {
@@ -124,25 +134,34 @@ export function evaluateDrift(
   }
 
   // Rule 5: CI_FAILURE_ON_SPRINT_BRANCH — sprint branch has failing CI
+  // Only report failures on active branches (open PR) or recent runs (< 7 days).
+  // Stale merged branches should not generate noise.
   if (workflowRuns) {
+    const now = Date.now();
     const sprintBranchRuns = workflowRuns.filter(r => r.headBranch.startsWith('sprint/'));
     for (const run of sprintBranchRuns) {
-      if (run.conclusion === 'failure') {
-        violations.push({
-          ruleId: 'CI_FAILURE_ON_SPRINT_BRANCH',
-          severity: 'error',
-          entityType: 'pr',
-          entityId: `run:${run.id}`,
-          entityTitle: run.name,
-          message: `CI workflow "${run.name}" failed on sprint branch ${run.headBranch}`,
-          evidence: {
-            branch: run.headBranch,
-            sha: run.headSha,
-            conclusion: run.conclusion,
-            url: run.url,
-          },
-        });
+      if (run.conclusion !== 'failure') continue;
+
+      // Skip stale runs on branches with no open PR
+      if (!activeBranches.has(run.headBranch)) {
+        const runAge = now - new Date(run.createdAt).getTime();
+        if (runAge > STALE_THRESHOLD_MS) continue;
       }
+
+      violations.push({
+        ruleId: 'CI_FAILURE_ON_SPRINT_BRANCH',
+        severity: 'error',
+        entityType: 'pr',
+        entityId: `run:${run.id}`,
+        entityTitle: run.name,
+        message: `CI workflow "${run.name}" failed on sprint branch ${run.headBranch}`,
+        evidence: {
+          branch: run.headBranch,
+          sha: run.headSha,
+          conclusion: run.conclusion,
+          url: run.url,
+        },
+      });
     }
   }
 

--- a/tools/huly-os/daemon/operator-cli.ts
+++ b/tools/huly-os/daemon/operator-cli.ts
@@ -1,6 +1,8 @@
-// SPRINT-HULY-OPERATOR-014: CLI entry point for operator + reports
+// SPRINT-HULY-OPERATOR-CLI-FIX-015A: CLI entry point for operator + reports
 // Usage:
-//   pnpm -C tools/huly-os run huly:operator -- [options]
+//   pnpm -C tools/huly-os run huly:operator          (continuous loop)
+//   pnpm -C tools/huly-os run huly:operator:once      (single cycle)
+//   pnpm -C tools/huly-os run huly:operator -- --once  (single cycle, flag style)
 //   pnpm -C tools/huly-os run huly:report:daily
 //   pnpm -C tools/huly-os run huly:report:weekly
 
@@ -14,48 +16,70 @@ import { publishDailyReport, publishWeeklyReport } from './report-generator.js';
 
 loadDotenv({ path: resolve(import.meta.dirname ?? '.', '..', '.env') });
 
+// ── Argv Sanitization ───────────────────────────────────────────────────
+// pnpm injects a literal "--" separator between script args and user args.
+// tsx may also shift argv positions. Strip ALL bare "--" arguments that are
+// not part of a known flag value to prevent commander from choking.
+const argv = process.argv.filter(arg => arg !== '--');
+
+// ── Shared operator action ──────────────────────────────────────────────
+
+async function runOperator(opts: { once?: boolean; interval: string }): Promise<void> {
+  const intervalSec = parseInt(opts.interval, 10);
+  if (isNaN(intervalSec) || intervalSec < 5) {
+    console.error('Interval must be >= 5 seconds');
+    process.exit(1);
+  }
+
+  const state = await startOperatorLoop({
+    once: opts.once,
+    intervalSec,
+  });
+
+  if (opts.once) {
+    if (state.lastResult) {
+      console.log('\n── Operator Cycle Result ──');
+      console.log(JSON.stringify(state.lastResult, null, 2));
+    }
+    const hasErrors = (state.lastResult?.errors.length ?? 0) > 0;
+    process.exit(hasErrors ? 1 : 0);
+  }
+
+  // Long-running mode — handle shutdown
+  const shutdown = () => {
+    console.log('\n[operator] Received shutdown signal');
+    stopOperatorLoop(state);
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  // Keep-alive
+  await new Promise(() => {});
+}
+
+// ── CLI Definition ──────────────────────────────────────────────────────
+
 const program = new Command();
 
-program.name('huly-operator').description('HULY-OS Autonomous Operator').version('1.0.0');
-
 program
-  .command('run')
-  .description('Start the operator polling loop')
+  .name('huly-operator')
+  .description('HULY-OS Autonomous Operator')
+  .version('1.0.0')
   .option('--once', 'Run exactly one cycle then exit')
   .option('--interval <seconds>', 'Polling interval in seconds', '60')
   .action(async (opts: { once?: boolean; interval: string }) => {
-    const intervalSec = parseInt(opts.interval, 10);
-    if (isNaN(intervalSec) || intervalSec < 5) {
-      console.error('Interval must be >= 5 seconds');
-      process.exit(1);
-    }
+    await runOperator(opts);
+  });
 
-    const state = await startOperatorLoop({
-      once: opts.once,
-      intervalSec,
-    });
-
-    if (opts.once) {
-      // Single cycle — report and exit
-      if (state.lastResult) {
-        console.log('\n── Operator Cycle Result ──');
-        console.log(JSON.stringify(state.lastResult, null, 2));
-      }
-      const hasErrors = (state.lastResult?.errors.length ?? 0) > 0;
-      process.exit(hasErrors ? 1 : 0);
-    }
-
-    // Long-running mode — handle shutdown
-    const shutdown = () => {
-      console.log('\n[operator] Received shutdown signal');
-      stopOperatorLoop(state);
-      process.exit(0);
-    };
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
-
-    // Keep-alive
-    await new Promise(() => {});
+// Keep 'run' as an explicit subcommand alias for backwards compatibility
+program
+  .command('run')
+  .description('Start the operator polling loop (alias for default)')
+  .option('--once', 'Run exactly one cycle then exit')
+  .option('--interval <seconds>', 'Polling interval in seconds', '60')
+  .action(async (opts: { once?: boolean; interval: string }) => {
+    await runOperator(opts);
   });
 
 program
@@ -85,14 +109,6 @@ program
       process.exit(1);
     }
   });
-
-// Default command: if invoked without a subcommand, show help
-program.command('help-operator', { isDefault: true, hidden: true }).action(() => {
-  program.outputHelp();
-});
-
-// Strip pnpm '--' separator
-const argv = process.argv.filter((arg, i) => !(arg === '--' && i === 2));
 
 program.parseAsync(argv).catch(err => {
   console.error('FATAL:', err instanceof Error ? err.message : err);

--- a/tools/huly-os/daemon/operator.ts
+++ b/tools/huly-os/daemon/operator.ts
@@ -304,9 +304,31 @@ export async function runOperatorCycle(opts?: {
   }
 
   // ── Phase 5: Additional Drift/Incident Rules ─────────────────────────
+
+  // Build set of "active" sprint branches — those with at least one open PR.
+  // Branches that are fully merged have no open work and should not generate
+  // new incidents or drift issues (prevents stale noise).
+  const activeBranches = new Set<string>();
+  for (const pr of openPRs) {
+    if (pr.headBranch.startsWith('sprint/')) {
+      activeBranches.add(pr.headBranch);
+    }
+  }
+
+  // Also treat workflow runs younger than 7 days as potentially active
+  // (covers branches where the PR was just opened or CI re-triggered).
+  const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+  const now = Date.now();
+
   // CI Failure Incidents (per sprint branch, per run — idempotent)
   for (const run of workflowRuns) {
     if (run.conclusion !== 'failure') continue;
+
+    // Skip stale runs on branches with no open PR
+    if (!activeBranches.has(run.headBranch)) {
+      const runAge = now - new Date(run.createdAt).getTime();
+      if (runAge > STALE_THRESHOLD_MS) continue;
+    }
 
     const sprintId =
       extractSprintId([run.headBranch]) ?? branchToNormalizedSprintId(run.headBranch);

--- a/tools/huly-os/package.json
+++ b/tools/huly-os/package.json
@@ -12,6 +12,7 @@
     "event:emit": "tsx daemon/event-bus/emit-cli.ts",
     "huly:ops": "tsx daemon/huly-ops.ts",
     "huly:operator": "tsx daemon/operator-cli.ts",
+    "huly:operator:once": "tsx daemon/operator-cli.ts --once",
     "huly:report:daily": "tsx daemon/operator-cli.ts report-daily",
     "huly:report:weekly": "tsx daemon/operator-cli.ts report-weekly",
     "huly:backfill": "tsx scripts/backfill-huly-issues.ts",


### PR DESCRIPTION
## Summary
- Fix operator CLI so `--once` and `--interval` work as top-level options (no `run` subcommand required)
- Strip all bare `--` from argv to prevent pnpm separator poisoning (`tsx cli.ts "--" "--once"`)
- Add `huly:operator:once` pnpm script for explicit one-shot invocation
- Add staleness guards to incident/drift creation: only fire for branches with open PRs or workflow runs < 7 days old
- Suppress stale CI failure noise from fully-merged sprint branches

## Bug Evidence (before)
```
$ pnpm -C tools/huly-os run huly:operator -- --once
error: unknown option '--once'
```

## Verification (after)
```
$ pnpm -C tools/huly-os run huly:operator:once
[operator] Starting single cycle
[operator] Cycle complete in 12132ms — 23 sprints, 0 transitions, 3 incidents, 0 drift, 0 errors
```

- `huly:operator -- --once` now works (argv sanitization)
- `huly:operator:once` explicit script works
- Stale CI failures on merged branches suppressed
- Doctor: 7/7 HEALTHY

## Test plan
- [x] `pnpm -C tools/huly-os run huly:operator -- --help` shows --once/--interval as top-level options
- [x] `pnpm -C tools/huly-os run huly:operator:once` runs single cycle, exits 0
- [x] `pnpm -C tools/huly-os run huly:operator -- --once` no longer errors
- [x] `pnpm -C tools/huly-os run huly:ops -- doctor` — 7/7 HEALTHY
- [x] `pnpm -C tools/huly-os run huly:report:daily` — drift errors reduced (staleness filter)
- [x] Pre-commit hooks pass (prettier, eslint, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)