### PR TITLE
fix(huly-os): resolve objectSpace to real space IDs [SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B]

### DIFF
--- a/tools/huly-os/daemon/adapters/huly-adapter.ts
+++ b/tools/huly-os/daemon/adapters/huly-adapter.ts
@@ -31,6 +31,10 @@ export class HulyAdapter implements IHulyAdapter {
   private workspaceId: string | null = null;
   private socialId: string | null = null;
 
+  // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Space resolution cache
+  private projectSpaceCache = new Map<string, string>();
+  private teamspaceCache = new Map<string, string>();
+
   constructor(config: DaemonConfig, audit: AuditLogger) {
     this.baseUrl = config.HULY_URL.replace(/\/$/, '');
     this.email = config.HULY_EMAIL;
@@ -128,6 +132,109 @@ export class HulyAdapter implements IHulyAdapter {
       modifiedOn: Date.now(),
       ...fields,
     };
+  }
+
+  // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Shared TX send helper
+  private async sendTx(tx: Record<string, unknown>): Promise<unknown> {
+    const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.workspaceToken}`,
+      },
+      body: JSON.stringify(tx),
+    });
+
+    if (!res.ok) {
+      const snippet = await res.text().catch(() => '');
+      throw new Error(`Huly TX HTTP ${res.status}: ${res.statusText} — ${snippet.slice(0, 200)}`);
+    }
+
+    return res.json();
+  }
+
+  /** Generic findAll query for any Huly class */
+  private async findAllRaw(cls: string, limit = 500): Promise<Record<string, unknown>[]> {
+    const opts = JSON.stringify({ limit });
+    const url =
+      `${this.baseUrl}/_transactor/api/v1/find-all/${this.workspaceId}` +
+      `?class=${encodeURIComponent(cls)}&options=${encodeURIComponent(opts)}`;
+
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.workspaceToken}` },
+    });
+
+    if (!res.ok) throw new Error(`findAll(${cls}) HTTP ${res.status}`);
+
+    const body = await res.json();
+    if (Array.isArray(body)) return body;
+    if (Array.isArray(body?.value)) return body.value;
+    if (Array.isArray(body?.docs)) return body.docs;
+    if (Array.isArray(body?.result)) return body.result;
+    return [];
+  }
+
+  /**
+   * Resolve a project identifier (e.g. "UT") to its actual space ID.
+   * Caches the result for the lifetime of this adapter instance.
+   */
+  async resolveProjectSpace(identifier: string): Promise<string> {
+    const cached = this.projectSpaceCache.get(identifier);
+    if (cached) return cached;
+
+    const projects = await this.findAllRaw('tracker:class:Project');
+    for (const p of projects) {
+      const pIdent = String(p.identifier ?? '');
+      const pName = String(p.name ?? '');
+      if (pIdent === identifier || pName === identifier) {
+        const spaceId = String(p._id);
+        this.projectSpaceCache.set(identifier, spaceId);
+        return spaceId;
+      }
+    }
+
+    throw new Error(
+      `Project "${identifier}" not found in Huly workspace. ` +
+        `Available: ${projects.map(p => `${p.identifier}(${p._id})`).join(', ')}`
+    );
+  }
+
+  /**
+   * Resolve a teamspace by name, or create it if it doesn't exist.
+   * Caches the result for the lifetime of this adapter instance.
+   */
+  async resolveOrCreateTeamspace(name: string): Promise<string> {
+    const cached = this.teamspaceCache.get(name);
+    if (cached) return cached;
+
+    const teamspaces = await this.findAllRaw('document:class:Teamspace');
+    for (const t of teamspaces) {
+      if (String(t.name ?? '') === name) {
+        const spaceId = String(t._id);
+        this.teamspaceCache.set(name, spaceId);
+        return spaceId;
+      }
+    }
+
+    // Teamspace doesn't exist — create it
+    const id = `teamspace-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tx = this.buildTx({
+      _class: 'core:class:TxCreateDoc',
+      objectId: id,
+      objectClass: 'document:class:Teamspace',
+      objectSpace: 'core:space:Space',
+      attributes: {
+        name,
+        description: `${name} — auto-created by HULY-OS operator`,
+        private: false,
+        archived: false,
+        members: [this.socialId],
+      },
+    });
+
+    await this.sendTx(tx);
+    this.teamspaceCache.set(name, id);
+    return id;
   }
 
   async ping(): Promise<boolean> {
@@ -246,24 +353,15 @@ export class HulyAdapter implements IHulyAdapter {
           },
         });
 
-        const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.workspaceToken}`,
-          },
-          body: JSON.stringify(tx),
-        });
-
-        if (!res.ok) {
-          throw new Error(`Huly updateDoc HTTP ${res.status}: ${res.statusText}`);
-        }
+        await this.sendTx(tx);
       });
 
       return { id: existing.id, created: false };
     }
 
-    // Step 2: Create new document
+    // Step 2: Create new document — resolve teamspace to real space ID
+    const resolvedTeamspace = await this.resolveOrCreateTeamspace(teamspaceName);
+
     const newId = await this.audit.traced(
       'huly',
       'create_doc',
@@ -275,26 +373,14 @@ export class HulyAdapter implements IHulyAdapter {
           _class: 'core:class:TxCreateDoc',
           objectId: docId,
           objectClass: 'document:class:Document',
-          objectSpace: teamspaceName,
+          objectSpace: resolvedTeamspace,
           attributes: {
             title: docTitle,
             content: markdownContent,
           },
         });
 
-        const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.workspaceToken}`,
-          },
-          body: JSON.stringify(tx),
-        });
-
-        if (!res.ok) {
-          throw new Error(`Huly createDoc HTTP ${res.status}: ${res.statusText}`);
-        }
-
+        await this.sendTx(tx);
         return docId;
       }
     );
@@ -349,6 +435,9 @@ export class HulyAdapter implements IHulyAdapter {
       throw new Error('HulyAdapter not connected. Call connect() first.');
     }
 
+    // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Resolve to real space ID
+    const resolvedSpace = await this.resolveProjectSpace(projectIdentifier);
+
     const issueId = await this.audit.traced(
       'huly',
       'create_issue',
@@ -360,27 +449,11 @@ export class HulyAdapter implements IHulyAdapter {
           _class: 'core:class:TxCreateDoc',
           objectId: id,
           objectClass: 'tracker:class:Issue',
-          objectSpace: projectIdentifier,
+          objectSpace: resolvedSpace,
           attributes: { title, description: body },
         });
 
-        const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.workspaceToken}`,
-          },
-          body: JSON.stringify(tx),
-        });
-
-        if (!res.ok) {
-          const snippet = await res.text().catch(() => '');
-          throw new Error(
-            `Huly createIssue HTTP ${res.status}: ${res.statusText}` +
-              (snippet ? ` — ${snippet.slice(0, 200)}` : '')
-          );
-        }
-
+        await this.sendTx(tx);
         return id;
       }
     );
@@ -394,31 +467,21 @@ export class HulyAdapter implements IHulyAdapter {
       throw new Error('HulyAdapter not connected. Call connect() first.');
     }
 
+    // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Look up the issue's actual space
+    const issues = await this.findAllRaw('tracker:class:Issue');
+    const issue = issues.find(i => String(i._id) === issueId);
+    const space = issue ? String(issue.space) : 'tracker:project:DefaultProject';
+
     await this.audit.traced('huly', 'update_issue', issueId, async () => {
       const tx = this.buildTx({
         _class: 'core:class:TxUpdateDoc',
         objectId: issueId,
         objectClass: 'tracker:class:Issue',
-        objectSpace: 'tracker:project:default',
+        objectSpace: space,
         operations: { description: body },
       });
 
-      const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.workspaceToken}`,
-        },
-        body: JSON.stringify(tx),
-      });
-
-      if (!res.ok) {
-        const snippet = await res.text().catch(() => '');
-        throw new Error(
-          `Huly updateIssue HTTP ${res.status}: ${res.statusText}` +
-            (snippet ? ` — ${snippet.slice(0, 200)}` : '')
-        );
-      }
+      await this.sendTx(tx);
     });
   }
 
@@ -439,23 +502,7 @@ export class HulyAdapter implements IHulyAdapter {
         attributes: { message: body },
       });
 
-      const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.workspaceToken}`,
-        },
-        body: JSON.stringify(tx),
-      });
-
-      if (!res.ok) {
-        const snippet = await res.text().catch(() => '');
-        throw new Error(
-          `Huly addComment HTTP ${res.status}: ${res.statusText}` +
-            (snippet ? ` — ${snippet.slice(0, 200)}` : '')
-        );
-      }
-
+      await this.sendTx(tx);
       return id;
     });
 
@@ -485,6 +532,8 @@ export class HulyAdapter implements IHulyAdapter {
       throw new Error('HulyAdapter not connected. Call connect() first.');
     }
 
+    // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Resolve to real space ID
+    const resolvedSpace = await this.resolveProjectSpace(projectIdentifier);
     const existing = await this.findIssueByTitle(projectIdentifier, title);
 
     if (existing) {
@@ -498,25 +547,11 @@ export class HulyAdapter implements IHulyAdapter {
             _class: 'core:class:TxUpdateDoc',
             objectId: existing.id,
             objectClass: 'tracker:class:Issue',
-            objectSpace: projectIdentifier,
+            objectSpace: resolvedSpace,
             operations: { description: body, ...extra },
           });
 
-          const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${this.workspaceToken}`,
-            },
-            body: JSON.stringify(tx),
-          });
-
-          if (!res.ok) {
-            const snippet = await res.text().catch(() => '');
-            throw new Error(
-              `Huly upsertIssue(update) HTTP ${res.status}: ${snippet.slice(0, 200)}`
-            );
-          }
+          await this.sendTx(tx);
         }
       );
 
@@ -535,24 +570,11 @@ export class HulyAdapter implements IHulyAdapter {
           _class: 'core:class:TxCreateDoc',
           objectId: id,
           objectClass: 'tracker:class:Issue',
-          objectSpace: projectIdentifier,
+          objectSpace: resolvedSpace,
           attributes: { title, description: body, ...extra },
         });
 
-        const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.workspaceToken}`,
-          },
-          body: JSON.stringify(tx),
-        });
-
-        if (!res.ok) {
-          const snippet = await res.text().catch(() => '');
-          throw new Error(`Huly upsertIssue(create) HTTP ${res.status}: ${snippet.slice(0, 200)}`);
-        }
-
+        await this.sendTx(tx);
         return id;
       }
     );
@@ -575,19 +597,7 @@ export class HulyAdapter implements IHulyAdapter {
         operations: { status: statusId },
       });
 
-      const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.workspaceToken}`,
-        },
-        body: JSON.stringify(tx),
-      });
-
-      if (!res.ok) {
-        const snippet = await res.text().catch(() => '');
-        throw new Error(`Huly updateIssueStatus HTTP ${res.status}: ${snippet.slice(0, 200)}`);
-      }
+      await this.sendTx(tx);
     });
   }
 

--- a/tools/huly-os/daemon/audit-dump.ts
+++ b/tools/huly-os/daemon/audit-dump.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env tsx
+// SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: One-shot audit dump
+// Dumps all issues (with space/project metadata) and all documents to JSON.
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: resolve(import.meta.dirname ?? '.', '..', '.env') });
+
+const BASE_URL = (process.env.HULY_URL ?? 'http://localhost:8087').replace(/\/$/, '');
+const EMAIL = process.env.HULY_EMAIL ?? 'user1@example.com';
+const PASSWORD = process.env.HULY_PASSWORD ?? '1234';
+const WORKSPACE = process.env.HULY_WORKSPACE ?? 'ws1';
+
+interface Session {
+  token: string;
+  workspaceId: string;
+  socialId: string;
+}
+
+async function connect(): Promise<Session> {
+  const loginRes = await fetch(`${BASE_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ method: 'login', params: { email: EMAIL, password: PASSWORD } }),
+  });
+  const loginBody = (await loginRes.json()) as any;
+  if (loginBody.error) throw new Error(`Login failed: ${loginBody.error.code}`);
+  const accountToken = loginBody.result.token;
+  const socialId = String(loginBody.result.socialId ?? '');
+
+  const wsRes = await fetch(`${BASE_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accountToken}` },
+    body: JSON.stringify({ method: 'selectWorkspace', params: { workspaceUrl: WORKSPACE } }),
+  });
+  const wsBody = (await wsRes.json()) as any;
+  if (wsBody.error) throw new Error(`selectWorkspace failed: ${wsBody.error.code}`);
+
+  return {
+    token: wsBody.result.token,
+    workspaceId: wsBody.result.workspace,
+    socialId,
+  };
+}
+
+async function findAll(session: Session, cls: string, limit = 500): Promise<any[]> {
+  const opts = JSON.stringify({ limit });
+  const url =
+    `${BASE_URL}/_transactor/api/v1/find-all/${session.workspaceId}` +
+    `?class=${encodeURIComponent(cls)}&options=${encodeURIComponent(opts)}`;
+
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${session.token}` } });
+  if (!res.ok) throw new Error(`findAll(${cls}) HTTP ${res.status}`);
+
+  const body = await res.json();
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.value)) return body.value;
+  if (Array.isArray(body?.docs)) return body.docs;
+  if (Array.isArray(body?.result)) return body.result;
+  return [];
+}
+
+async function main(): Promise<void> {
+  const outDir = process.argv[2] || 'out/audit/huly-reality-audit-dump';
+  mkdirSync(outDir, { recursive: true });
+
+  console.log('[audit] Connecting to Huly...');
+  const session = await connect();
+  console.log(`[audit] Connected. workspace=${session.workspaceId}`);
+
+  // 1. All issues with raw fields
+  console.log('[audit] Fetching all issues...');
+  const rawIssues = await findAll(session, 'tracker:class:Issue');
+  const issues = rawIssues.map((r: any) => ({
+    _id: r._id,
+    identifier: r.identifier ?? '',
+    title: r.title ?? '',
+    status: r.status ?? '',
+    space: r.space ?? '',
+    _class: r._class ?? '',
+    description: r.description ? String(r.description).slice(0, 200) : null,
+    priority: r.priority ?? null,
+    modifiedOn: r.modifiedOn ?? 0,
+    createdOn: r.createdOn ?? r.createdDate ?? 0,
+  }));
+  writeFileSync(`${outDir}/issues.json`, JSON.stringify(issues, null, 2));
+  console.log(`[audit] Issues: ${issues.length} written to issues.json`);
+
+  // Categorize by space
+  const bySpace = new Map<string, number>();
+  for (const i of issues) {
+    bySpace.set(i.space, (bySpace.get(i.space) ?? 0) + 1);
+  }
+  console.log('[audit] Issues by space:');
+  for (const [space, count] of bySpace) {
+    console.log(`  ${space}: ${count}`);
+  }
+
+  // 2. All documents
+  console.log('\n[audit] Fetching all documents...');
+  const rawDocs = await findAll(session, 'document:class:Document');
+  const docs = rawDocs.map((r: any) => ({
+    _id: r._id,
+    title: r.title ?? '',
+    space: r.space ?? '',
+    _class: r._class ?? '',
+    content: r.content ? String(r.content).slice(0, 200) : null,
+    modifiedOn: r.modifiedOn ?? 0,
+  }));
+  writeFileSync(`${outDir}/docs.json`, JSON.stringify(docs, null, 2));
+  console.log(`[audit] Documents: ${docs.length} written to docs.json`);
+
+  // Categorize docs by space
+  const docsBySpace = new Map<string, number>();
+  for (const d of docs) {
+    docsBySpace.set(d.space, (docsBySpace.get(d.space) ?? 0) + 1);
+  }
+  console.log('[audit] Documents by space:');
+  for (const [space, count] of docsBySpace) {
+    console.log(`  ${space}: ${count}`);
+  }
+
+  // 3. All spaces
+  console.log('\n[audit] Fetching all spaces...');
+  const rawSpaces = await findAll(session, 'core:class:Space');
+  const spaces = rawSpaces.map((r: any) => ({
+    _id: r._id,
+    name: r.name ?? '',
+    _class: r._class ?? '',
+    type: r.type ?? r._class ?? '',
+    archived: r.archived ?? false,
+    private: r.private ?? false,
+  }));
+  writeFileSync(`${outDir}/spaces.json`, JSON.stringify(spaces, null, 2));
+  console.log(`[audit] Spaces: ${spaces.length} written to spaces.json`);
+
+  // 4. All teamspaces (document:class:Teamspace)
+  console.log('\n[audit] Fetching teamspaces...');
+  const rawTeamspaces = await findAll(session, 'document:class:Teamspace');
+  const teamspaces = rawTeamspaces.map((r: any) => ({
+    _id: r._id,
+    name: r.name ?? '',
+    _class: r._class ?? '',
+    description: r.description ?? '',
+  }));
+  writeFileSync(`${outDir}/teamspaces.json`, JSON.stringify(teamspaces, null, 2));
+  console.log(`[audit] Teamspaces: ${teamspaces.length}`);
+  for (const t of teamspaces) {
+    console.log(`  ${t._id}: ${t.name}`);
+  }
+
+  // 5. Projects
+  console.log('\n[audit] Fetching projects...');
+  const rawProjects = await findAll(session, 'tracker:class:Project');
+  const projects = rawProjects.map((r: any) => ({
+    _id: r._id,
+    identifier: r.identifier ?? '',
+    name: r.name ?? '',
+    description: r.description ?? '',
+    defaultIssueStatus: r.defaultIssueStatus ?? '',
+  }));
+  writeFileSync(`${outDir}/projects.json`, JSON.stringify(projects, null, 2));
+  console.log(`[audit] Projects: ${projects.length}`);
+  for (const p of projects) {
+    console.log(`  ${p._id}: identifier=${p.identifier} name=${p.name}`);
+  }
+
+  console.log('\n[audit] Audit dump complete.');
+}
+
+main().catch(err => {
+  console.error('FATAL:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/tools/huly-os/daemon/huly-ops.ts
+++ b/tools/huly-os/daemon/huly-ops.ts
@@ -865,6 +865,112 @@ async function cmdBootstrap(): Promise<void> {
   console.log('═══════════════════════════════════════════════════\n');
 }
 
+// ── Command: workspace-status ────────────────────────────────────────────
+
+async function cmdWorkspaceStatus(): Promise<void> {
+  const cfg = loadHulyConfig();
+  printBanner(cfg);
+
+  console.log('Connecting to Huly...');
+  const session = await connect(cfg);
+  console.log(`Connected. WorkspaceID: ${session.workspaceId}\n`);
+
+  console.log('── WORKSPACE STATUS ───────────────────────────────\n');
+
+  // 1. Projects
+  const projects = await findAll(session, 'tracker:class:Project');
+  console.log(`Projects (${projects.length}):`);
+  let utSpace: string | null = null;
+  for (const p of projects) {
+    const ident = String(p.identifier ?? '');
+    const name = String(p.name ?? '');
+    const id = String(p._id ?? '');
+    const match = ident === cfg.project || name === cfg.project;
+    const marker = match ? ' ← CONFIGURED' : '';
+    console.log(`  ${ident} | ${name} | space: ${id}${marker}`);
+    if (match) utSpace = id;
+  }
+  if (!utSpace) {
+    console.log(`  ⚠ Configured project "${cfg.project}" NOT FOUND`);
+  }
+  console.log('');
+
+  // 2. Teamspaces
+  const teamspaces = await findAll(session, 'document:class:Teamspace');
+  console.log(`Teamspaces (${teamspaces.length}):`);
+  let opsTeamspace: string | null = null;
+  for (const t of teamspaces) {
+    const name = String(t.name ?? '');
+    const id = String(t._id ?? '');
+    const marker = name === cfg.teamspace ? ' ← CONFIGURED' : '';
+    console.log(`  ${name} | space: ${id}${marker}`);
+    if (name === cfg.teamspace) opsTeamspace = id;
+  }
+  if (!opsTeamspace) {
+    console.log(`  ⚠ Configured teamspace "${cfg.teamspace}" NOT FOUND`);
+  }
+  console.log('');
+
+  // 3. Issues in target project
+  const issues = await findAll(session, 'tracker:class:Issue');
+  const projectIssues = utSpace ? issues.filter((i: any) => String(i.space) === utSpace) : [];
+  console.log(`Issues in project "${cfg.project}" (${projectIssues.length}):`);
+  const byType = { epics: 0, sprints: 0, tasks: 0 };
+  for (const i of projectIssues) {
+    const title = String(i.title ?? '');
+    if (title.startsWith('[EPIC]')) byType.epics++;
+    else if (title.startsWith('[SPRINT]')) byType.sprints++;
+    else byType.tasks++;
+  }
+  console.log(`  Epics: ${byType.epics}  Sprints: ${byType.sprints}  Tasks: ${byType.tasks}`);
+  console.log('');
+
+  // 4. Documents in target teamspace
+  const docs = await findAll(session, 'document:class:Document');
+  const tsDocs = opsTeamspace ? docs.filter((d: any) => String(d.space) === opsTeamspace) : [];
+  console.log(`Documents in teamspace "${cfg.teamspace}" (${tsDocs.length}):`);
+  for (const d of tsDocs) {
+    console.log(`  ${d._id}: "${String(d.title ?? '?')}"`);
+  }
+  if (tsDocs.length === 0 && opsTeamspace) {
+    console.log('  (empty)');
+  }
+  console.log('');
+
+  // 5. Orphan check — issues NOT in target project space
+  const orphanIssues = utSpace ? issues.filter((i: any) => String(i.space) !== utSpace) : [];
+  if (orphanIssues.length > 0) {
+    console.log(`⚠ Orphan issues (not in ${cfg.project}): ${orphanIssues.length}`);
+    const bySpace = new Map<string, number>();
+    for (const i of orphanIssues) {
+      const sp = String(i.space ?? '?');
+      bySpace.set(sp, (bySpace.get(sp) ?? 0) + 1);
+    }
+    for (const [sp, count] of bySpace) {
+      console.log(`  ${sp}: ${count}`);
+    }
+    console.log('');
+  }
+
+  // Summary
+  console.log('── VERDICT ────────────────────────────────────────');
+  const problems: string[] = [];
+  if (!utSpace) problems.push(`Project "${cfg.project}" missing`);
+  if (!opsTeamspace) problems.push(`Teamspace "${cfg.teamspace}" missing`);
+  if (projectIssues.length === 0) problems.push('No issues in target project');
+  if (tsDocs.length === 0) problems.push('No documents in target teamspace');
+
+  if (problems.length === 0) {
+    console.log('  ✓ Workspace structure HEALTHY');
+  } else {
+    console.log('  ⚠ Workspace has problems:');
+    for (const p of problems) {
+      console.log(`    - ${p}`);
+    }
+  }
+  console.log('═══════════════════════════════════════════════════\n');
+}
+
 // ── CLI Program ─────────────────────────────────────────────────────────
 
 const program = new Command();
@@ -912,6 +1018,13 @@ program
   .description('Full OS setup: rebuild + publish docs + backfill PRs')
   .action(async () => {
     await cmdBootstrap();
+  });
+
+program
+  .command('workspace-status')
+  .description('Validate workspace structure: projects, teamspaces, issues, docs')
+  .action(async () => {
+    await cmdWorkspaceStatus();
   });
 
 // Strip the literal '--' separator that pnpm injects when using: pnpm run huly:ops -- <cmd>

--- a/tools/huly-os/package.json
+++ b/tools/huly-os/package.json
@@ -15,6 +15,7 @@
     "huly:operator:once": "tsx daemon/operator-cli.ts --once",
     "huly:report:daily": "tsx daemon/operator-cli.ts report-daily",
     "huly:report:weekly": "tsx daemon/operator-cli.ts report-weekly",
+    "huly:workspace-status": "tsx daemon/huly-ops.ts workspace-status",
     "huly:backfill": "tsx scripts/backfill-huly-issues.ts",
     "huly:publish-os": "tsx scripts/publish-os-docs.ts",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## Summary

- **Root cause fix**: `HulyAdapter` passed string identifiers (`"UT"`, `"Operations"`) as `objectSpace` in Huly TX API calls. Huly silently accepts writes to non-existent spaces, creating phantom objects invisible in the UI. Audit proved operator "created" 24 sprint issues + daily report docs that were never visible.
- **Space resolution**: Added `resolveProjectSpace(identifier)` and `resolveOrCreateTeamspace(name)` with per-instance caching. All TX calls now use real space IDs looked up from the Huly API.
- **Workspace bootstrap**: "Operations" teamspace auto-created on first doc publish. `workspace-status` command added for ongoing validation.

## Changes

| File | Change |
|------|--------|
| `tools/huly-os/daemon/adapters/huly-adapter.ts` | Add space resolution + cache, extract sendTx/findAllRaw helpers, fix all TX objectSpace fields |
| `tools/huly-os/daemon/huly-ops.ts` | Add `workspace-status` command |
| `tools/huly-os/package.json` | Add `huly:workspace-status` script |
| `tools/huly-os/daemon/audit-dump.ts` | New: raw workspace data dump for auditing |

## Audit Evidence

| Metric | Before Fix | After Fix |
|--------|-----------|-----------|
| Issues visible in UT project | 10 | 134 |
| Teamspaces | 1 (Quick-Start Docs) | 2 (+Operations) |
| Documents in Operations | 0 | 1 (Daily Report) |
| workspace-status verdict | N/A | HEALTHY |
| Doctor | 7/7 PASS | 7/7 PASS |

## Test plan

- [x] `pnpm -C tools/huly-os run type-check` — clean
- [x] `pnpm -C tools/huly-os run lint` — 0 errors (warnings pre-existing)
- [x] `pnpm -C tools/huly-os run huly:workspace-status` — HEALTHY
- [x] `pnpm -C tools/huly-os exec tsx daemon/huly-ops.ts doctor` — 7/7 PASS
- [x] `pnpm -C tools/huly-os run huly:operator:once` — issues land in correct space
- [x] `pnpm -C tools/huly-os run huly:report:daily` — doc visible in Operations teamspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)