### PR TITLE
fix(huly-os): WebSocket TX + collection fields for UI visibility

### DIFF
--- a/tools/huly-os/daemon/adapters/huly-adapter.ts
+++ b/tools/huly-os/daemon/adapters/huly-adapter.ts
@@ -1,9 +1,17 @@
 // SPRINT-HULY-WORKOS-V1-LOCAL-001: Huly adapter via HTTP REST API
-// Uses: /_accounts/ (JSON-RPC) + /_transactor/api/v1/ (REST)
+// SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017: WebSocket TX for LiveQuery visibility
+// Uses: /_accounts/ (JSON-RPC) + WebSocket (TX writes) + REST (reads)
 
 import type { AuditLogger } from '../audit-log.js';
 import type { DaemonConfig } from '../config.js';
 import type { HulyIssue, HulyStatusId, IHulyAdapter } from './types.js';
+
+/** Pending WebSocket RPC request */
+interface WsPendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
 
 /** Regex to extract proof_url from issue description */
 const PROOF_URL_RE = /proof_url:\s*(https?:\/\/\S+|out\/proofs\/\S+)/i;
@@ -30,6 +38,17 @@ export class HulyAdapter implements IHulyAdapter {
   private workspaceToken: string | null = null;
   private workspaceId: string | null = null;
   private socialId: string | null = null;
+
+  // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Space resolution cache
+  private projectSpaceCache = new Map<string, string>();
+  private teamspaceCache = new Map<string, string>();
+  // SPRINT-UI-AUDIT-2026-03-04: Project metadata cache
+  private projectMetaCache = new Map<string, Record<string, unknown>>();
+
+  // SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017: WebSocket TX for LiveQuery visibility
+  private ws: WebSocket | null = null;
+  private wsReqId = 0;
+  private wsPending = new Map<number, WsPendingRequest>();
 
   constructor(config: DaemonConfig, audit: AuditLogger) {
     this.baseUrl = config.HULY_URL.replace(/\/$/, '');
@@ -110,9 +129,111 @@ export class HulyAdapter implements IHulyAdapter {
     const loginResult = await this.login();
     this.accountToken = loginResult.token;
     this.socialId = loginResult.socialId;
-    const ws = await this.selectWorkspace(this.accountToken);
-    this.workspaceToken = ws.token;
-    this.workspaceId = ws.workspace;
+    const wsInfo = await this.selectWorkspace(this.accountToken);
+    this.workspaceToken = wsInfo.token;
+    this.workspaceId = wsInfo.workspace;
+
+    // SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017: Open WebSocket for TX writes
+    await this.connectWebSocket();
+  }
+
+  /**
+   * Open WebSocket to transactor using the same protocol as the Huly frontend.
+   * JWT goes in the URL path (matches nginx /eyJ route → transactor).
+   * Hello handshake negotiates JSON mode (no binary/compression).
+   */
+  private async connectWebSocket(): Promise<void> {
+    if (!this.workspaceToken) throw new Error('No workspace token for WebSocket');
+
+    const wsUrl = this.baseUrl.replace(/^http/, 'ws');
+    const url = `${wsUrl}/${this.workspaceToken}`;
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('WebSocket connection timeout (10s)'));
+      }, 10_000);
+
+      const socket = new WebSocket(url);
+
+      socket.onopen = () => {
+        // Send hello handshake — JSON mode, no binary/compression
+        socket.send(
+          JSON.stringify({
+            method: 'hello',
+            params: [],
+            id: -1,
+            binary: false,
+            compression: false,
+          })
+        );
+      };
+
+      socket.onmessage = async (event: MessageEvent) => {
+        let data: Record<string, unknown>;
+        try {
+          // Node 22 native WebSocket may deliver data as Blob
+          const raw = event.data instanceof Blob ? await event.data.text() : String(event.data);
+          data = JSON.parse(raw);
+        } catch {
+          return; // Ignore unparseable frames
+        }
+
+        // Hello response (id === -1)
+        if (data.id === -1) {
+          clearTimeout(timeout);
+          this.ws = socket;
+          resolve();
+          return;
+        }
+
+        // TX response — route to pending request by id
+        if (typeof data.id === 'number') {
+          const pending = this.wsPending.get(data.id);
+          if (pending) {
+            this.wsPending.delete(data.id);
+            clearTimeout(pending.timer);
+            if (data.error) {
+              pending.reject(new Error(`WS TX error: ${JSON.stringify(data.error)}`));
+            } else {
+              pending.resolve(data.result);
+            }
+          }
+          return;
+        }
+
+        // Broadcasts (no id) — ignore silently
+      };
+
+      socket.onerror = () => {
+        clearTimeout(timeout);
+        this.ws = null;
+        // Don't reject — fall back to REST silently
+        resolve();
+      };
+
+      socket.onclose = () => {
+        this.ws = null;
+        // Reject any pending requests
+        for (const [id, pending] of this.wsPending) {
+          clearTimeout(pending.timer);
+          pending.reject(new Error('WebSocket closed'));
+          this.wsPending.delete(id);
+        }
+      };
+    });
+  }
+
+  /** Close the WebSocket connection cleanly */
+  async disconnect(): Promise<void> {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    for (const [, pending] of this.wsPending) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('Adapter disconnected'));
+    }
+    this.wsPending.clear();
   }
 
   /**
@@ -128,6 +249,208 @@ export class HulyAdapter implements IHulyAdapter {
       modifiedOn: Date.now(),
       ...fields,
     };
+  }
+
+  // SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017: WebSocket TX primary, REST fallback
+  private async sendTx(tx: Record<string, unknown>): Promise<unknown> {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      return this.wsSendTx(tx);
+    }
+    return this.restSendTx(tx);
+  }
+
+  /** Send TX over WebSocket — enters LiveQuery broadcast pipeline */
+  private wsSendTx(tx: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = ++this.wsReqId;
+      const timer = setTimeout(() => {
+        this.wsPending.delete(id);
+        reject(new Error(`WS TX timeout (30s) for request #${id}`));
+      }, 30_000);
+
+      this.wsPending.set(id, { resolve, reject, timer });
+
+      this.ws!.send(
+        JSON.stringify({
+          method: 'tx',
+          params: [tx],
+          id,
+          time: Date.now(),
+        })
+      );
+    });
+  }
+
+  /** Send TX over REST — data persists but may not trigger LiveQuery */
+  private async restSendTx(tx: Record<string, unknown>): Promise<unknown> {
+    const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.workspaceToken}`,
+      },
+      body: JSON.stringify(tx),
+    });
+
+    if (!res.ok) {
+      const snippet = await res.text().catch(() => '');
+      throw new Error(`Huly TX HTTP ${res.status}: ${res.statusText} — ${snippet.slice(0, 200)}`);
+    }
+
+    return res.json();
+  }
+
+  /** Generic findAll query for any Huly class */
+  private async findAllRaw(cls: string, limit = 500): Promise<Record<string, unknown>[]> {
+    const opts = JSON.stringify({ limit });
+    const url =
+      `${this.baseUrl}/_transactor/api/v1/find-all/${this.workspaceId}` +
+      `?class=${encodeURIComponent(cls)}&options=${encodeURIComponent(opts)}`;
+
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.workspaceToken}` },
+    });
+
+    if (!res.ok) throw new Error(`findAll(${cls}) HTTP ${res.status}`);
+
+    const body = await res.json();
+    if (Array.isArray(body)) return body;
+    if (Array.isArray(body?.value)) return body.value;
+    if (Array.isArray(body?.docs)) return body.docs;
+    if (Array.isArray(body?.result)) return body.result;
+    return [];
+  }
+
+  /**
+   * Resolve a project identifier (e.g. "UT") to its actual space ID.
+   * Caches the result for the lifetime of this adapter instance.
+   */
+  async resolveProjectSpace(identifier: string): Promise<string> {
+    const cached = this.projectSpaceCache.get(identifier);
+    if (cached) return cached;
+
+    const projects = await this.findAllRaw('tracker:class:Project');
+    for (const p of projects) {
+      const pIdent = String(p.identifier ?? '');
+      const pName = String(p.name ?? '');
+      if (pIdent === identifier || pName === identifier) {
+        const spaceId = String(p._id);
+        this.projectSpaceCache.set(identifier, spaceId);
+        return spaceId;
+      }
+    }
+
+    throw new Error(
+      `Project "${identifier}" not found in Huly workspace. ` +
+        `Available: ${projects.map(p => `${p.identifier}(${p._id})`).join(', ')}`
+    );
+  }
+
+  /**
+   * Resolve a teamspace by name, or create it if it doesn't exist.
+   * Caches the result for the lifetime of this adapter instance.
+   */
+  async resolveOrCreateTeamspace(name: string): Promise<string> {
+    const cached = this.teamspaceCache.get(name);
+    if (cached) return cached;
+
+    const teamspaces = await this.findAllRaw('document:class:Teamspace');
+    for (const t of teamspaces) {
+      if (String(t.name ?? '') === name) {
+        const spaceId = String(t._id);
+        this.teamspaceCache.set(name, spaceId);
+        return spaceId;
+      }
+    }
+
+    // Teamspace doesn't exist — create it
+    const id = `teamspace-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tx = this.buildTx({
+      _class: 'core:class:TxCreateDoc',
+      objectId: id,
+      objectClass: 'document:class:Teamspace',
+      objectSpace: 'core:space:Space',
+      attributes: {
+        name,
+        description: `${name} — auto-created by HULY-OS operator`,
+        private: false,
+        archived: false,
+        members: [this.socialId],
+      },
+    });
+
+    await this.sendTx(tx);
+    this.teamspaceCache.set(name, id);
+    return id;
+  }
+
+  /**
+   * Get full project metadata (cached).
+   * Used to read defaultIssueStatus, sequence, identifier, etc.
+   */
+  private async resolveProjectMeta(identifier: string): Promise<Record<string, unknown>> {
+    const cached = this.projectMetaCache.get(identifier);
+    if (cached) return cached;
+
+    const projects = await this.findAllRaw('tracker:class:Project');
+    for (const p of projects) {
+      const pIdent = String(p.identifier ?? '');
+      const pName = String(p.name ?? '');
+      if (pIdent === identifier || pName === identifier) {
+        this.projectMetaCache.set(identifier, p);
+        return p;
+      }
+    }
+    throw new Error(`Project "${identifier}" not found`);
+  }
+
+  /**
+   * Resolve the default issue status for a project.
+   * Falls back to tracker:status:Backlog if project has no default.
+   */
+  async resolveDefaultStatus(projectIdentifier: string): Promise<string> {
+    const meta = await this.resolveProjectMeta(projectIdentifier);
+    return String(meta.defaultIssueStatus ?? 'tracker:status:Backlog');
+  }
+
+  /**
+   * Get the next issue number for a project by incrementing its sequence counter.
+   * If the project has no sequence, initializes it by counting existing issues.
+   * Returns { number, identifier } e.g. { number: 11, identifier: "UT-11" }
+   */
+  async getNextIssueNumber(
+    projectIdentifier: string
+  ): Promise<{ number: number; identifier: string }> {
+    const meta = await this.resolveProjectMeta(projectIdentifier);
+    const spaceId = String(meta._id);
+    const ident = String(meta.identifier ?? projectIdentifier);
+
+    let seq = typeof meta.sequence === 'number' ? meta.sequence : 0;
+
+    if (seq === 0) {
+      // No sequence yet — count existing issues to initialize
+      const issues = await this.findAllRaw('tracker:class:Issue');
+      const projectIssues = issues.filter(i => String(i.space) === spaceId);
+      seq = projectIssues.length;
+    }
+
+    const nextNum = seq + 1;
+
+    // Update project sequence counter via TX
+    const tx = this.buildTx({
+      _class: 'core:class:TxUpdateDoc',
+      objectId: spaceId,
+      objectClass: 'tracker:class:Project',
+      objectSpace: 'core:space:Space',
+      operations: { sequence: nextNum },
+    });
+    await this.sendTx(tx);
+
+    // Update cached meta
+    meta.sequence = nextNum;
+    this.projectMetaCache.set(projectIdentifier, meta);
+
+    return { number: nextNum, identifier: `${ident}-${nextNum}` };
   }
 
   async ping(): Promise<boolean> {
@@ -246,24 +569,15 @@ export class HulyAdapter implements IHulyAdapter {
           },
         });
 
-        const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.workspaceToken}`,
-          },
-          body: JSON.stringify(tx),
-        });
-
-        if (!res.ok) {
-          throw new Error(`Huly updateDoc HTTP ${res.status}: ${res.statusText}`);
-        }
+        await this.sendTx(tx);
       });
 
       return { id: existing.id, created: false };
     }
 
-    // Step 2: Create new document
+    // Step 2: Create new document — resolve teamspace to real space ID
+    const resolvedTeamspace = await this.resolveOrCreateTeamspace(teamspaceName);
+
     const newId = await this.audit.traced(
       'huly',
       'create_doc',
@@ -275,26 +589,14 @@ export class HulyAdapter implements IHulyAdapter {
           _class: 'core:class:TxCreateDoc',
           objectId: docId,
           objectClass: 'document:class:Document',
-          objectSpace: teamspaceName,
+          objectSpace: resolvedTeamspace,
           attributes: {
             title: docTitle,
             content: markdownContent,
           },
         });
 
-        const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.workspaceToken}`,
-          },
-          body: JSON.stringify(tx),
-        });
-
-        if (!res.ok) {
-          throw new Error(`Huly createDoc HTTP ${res.status}: ${res.statusText}`);
-        }
-
+        await this.sendTx(tx);
         return docId;
       }
     );
@@ -349,6 +651,12 @@ export class HulyAdapter implements IHulyAdapter {
       throw new Error('HulyAdapter not connected. Call connect() first.');
     }
 
+    // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Resolve to real space ID
+    const resolvedSpace = await this.resolveProjectSpace(projectIdentifier);
+    // SPRINT-UI-AUDIT-2026-03-04: Set required fields for UI visibility
+    const defaultStatus = await this.resolveDefaultStatus(projectIdentifier);
+    const { number, identifier } = await this.getNextIssueNumber(projectIdentifier);
+
     const issueId = await this.audit.traced(
       'huly',
       'create_issue',
@@ -360,27 +668,37 @@ export class HulyAdapter implements IHulyAdapter {
           _class: 'core:class:TxCreateDoc',
           objectId: id,
           objectClass: 'tracker:class:Issue',
-          objectSpace: projectIdentifier,
-          attributes: { title, description: body },
-        });
-
-        const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.workspaceToken}`,
+          objectSpace: resolvedSpace,
+          attributes: {
+            title,
+            description: body,
+            status: defaultStatus,
+            number,
+            identifier,
+            kind: 'tracker:taskTypes:Issue',
+            // SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017: Required fields for trigger + LiveQuery
+            priority: 0,
+            component: null,
+            assignee: null,
+            estimation: 0,
+            remainingTime: 0,
+            reportedTime: 0,
+            reports: 0,
+            subIssues: 0,
+            parents: [],
+            childInfo: [],
+            relations: [],
+            dueDate: null,
+            rank: '0|hzzzzz:',
+            comments: 0,
+            // Collection fields — required for LiveQuery visibility
+            attachedTo: 'tracker:ids:NoParent',
+            attachedToClass: 'tracker:class:Issue',
+            collection: 'subIssues',
           },
-          body: JSON.stringify(tx),
         });
 
-        if (!res.ok) {
-          const snippet = await res.text().catch(() => '');
-          throw new Error(
-            `Huly createIssue HTTP ${res.status}: ${res.statusText}` +
-              (snippet ? ` — ${snippet.slice(0, 200)}` : '')
-          );
-        }
-
+        await this.sendTx(tx);
         return id;
       }
     );
@@ -394,31 +712,21 @@ export class HulyAdapter implements IHulyAdapter {
       throw new Error('HulyAdapter not connected. Call connect() first.');
     }
 
+    // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Look up the issue's actual space
+    const issues = await this.findAllRaw('tracker:class:Issue');
+    const issue = issues.find(i => String(i._id) === issueId);
+    const space = issue ? String(issue.space) : 'tracker:project:DefaultProject';
+
     await this.audit.traced('huly', 'update_issue', issueId, async () => {
       const tx = this.buildTx({
         _class: 'core:class:TxUpdateDoc',
         objectId: issueId,
         objectClass: 'tracker:class:Issue',
-        objectSpace: 'tracker:project:default',
+        objectSpace: space,
         operations: { description: body },
       });
 
-      const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.workspaceToken}`,
-        },
-        body: JSON.stringify(tx),
-      });
-
-      if (!res.ok) {
-        const snippet = await res.text().catch(() => '');
-        throw new Error(
-          `Huly updateIssue HTTP ${res.status}: ${res.statusText}` +
-            (snippet ? ` — ${snippet.slice(0, 200)}` : '')
-        );
-      }
+      await this.sendTx(tx);
     });
   }
 
@@ -439,23 +747,7 @@ export class HulyAdapter implements IHulyAdapter {
         attributes: { message: body },
       });
 
-      const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.workspaceToken}`,
-        },
-        body: JSON.stringify(tx),
-      });
-
-      if (!res.ok) {
-        const snippet = await res.text().catch(() => '');
-        throw new Error(
-          `Huly addComment HTTP ${res.status}: ${res.statusText}` +
-            (snippet ? ` — ${snippet.slice(0, 200)}` : '')
-        );
-      }
-
+      await this.sendTx(tx);
       return id;
     });
 
@@ -485,6 +777,8 @@ export class HulyAdapter implements IHulyAdapter {
       throw new Error('HulyAdapter not connected. Call connect() first.');
     }
 
+    // SPRINT-HULY-WORKSPACE-AUDIT-BOOTSTRAP-015B: Resolve to real space ID
+    const resolvedSpace = await this.resolveProjectSpace(projectIdentifier);
     const existing = await this.findIssueByTitle(projectIdentifier, title);
 
     if (existing) {
@@ -498,30 +792,20 @@ export class HulyAdapter implements IHulyAdapter {
             _class: 'core:class:TxUpdateDoc',
             objectId: existing.id,
             objectClass: 'tracker:class:Issue',
-            objectSpace: projectIdentifier,
+            objectSpace: resolvedSpace,
             operations: { description: body, ...extra },
           });
 
-          const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${this.workspaceToken}`,
-            },
-            body: JSON.stringify(tx),
-          });
-
-          if (!res.ok) {
-            const snippet = await res.text().catch(() => '');
-            throw new Error(
-              `Huly upsertIssue(update) HTTP ${res.status}: ${snippet.slice(0, 200)}`
-            );
-          }
+          await this.sendTx(tx);
         }
       );
 
       return { id: existing.id, created: false };
     }
+
+    // SPRINT-UI-AUDIT-2026-03-04: Set required fields for UI visibility
+    const defaultStatus = await this.resolveDefaultStatus(projectIdentifier);
+    const { number, identifier } = await this.getNextIssueNumber(projectIdentifier);
 
     // Create new issue
     const result = await this.audit.traced(
@@ -535,24 +819,38 @@ export class HulyAdapter implements IHulyAdapter {
           _class: 'core:class:TxCreateDoc',
           objectId: id,
           objectClass: 'tracker:class:Issue',
-          objectSpace: projectIdentifier,
-          attributes: { title, description: body, ...extra },
-        });
-
-        const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.workspaceToken}`,
+          objectSpace: resolvedSpace,
+          attributes: {
+            title,
+            description: body,
+            status: defaultStatus,
+            number,
+            identifier,
+            kind: 'tracker:taskTypes:Issue',
+            // SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017: Required fields for trigger + LiveQuery
+            priority: 0,
+            component: null,
+            assignee: null,
+            estimation: 0,
+            remainingTime: 0,
+            reportedTime: 0,
+            reports: 0,
+            subIssues: 0,
+            parents: [],
+            childInfo: [],
+            relations: [],
+            dueDate: null,
+            rank: '0|hzzzzz:',
+            comments: 0,
+            // Collection fields — required for LiveQuery visibility
+            attachedTo: 'tracker:ids:NoParent',
+            attachedToClass: 'tracker:class:Issue',
+            collection: 'subIssues',
+            ...extra,
           },
-          body: JSON.stringify(tx),
         });
 
-        if (!res.ok) {
-          const snippet = await res.text().catch(() => '');
-          throw new Error(`Huly upsertIssue(create) HTTP ${res.status}: ${snippet.slice(0, 200)}`);
-        }
-
+        await this.sendTx(tx);
         return id;
       }
     );
@@ -575,19 +873,7 @@ export class HulyAdapter implements IHulyAdapter {
         operations: { status: statusId },
       });
 
-      const res = await fetch(`${this.baseUrl}/_transactor/api/v1/tx/${this.workspaceId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.workspaceToken}`,
-        },
-        body: JSON.stringify(tx),
-      });
-
-      if (!res.ok) {
-        const snippet = await res.text().catch(() => '');
-        throw new Error(`Huly updateIssueStatus HTTP ${res.status}: ${snippet.slice(0, 200)}`);
-      }
+      await this.sendTx(tx);
     });
   }
 

--- a/tools/huly-os/daemon/adapters/types.ts
+++ b/tools/huly-os/daemon/adapters/types.ts
@@ -122,6 +122,7 @@ export type HulyStatusId = (typeof HULY_STATUS)[keyof typeof HULY_STATUS];
 /** Huly platform adapter interface */
 export interface IHulyAdapter {
   connect(): Promise<void>;
+  disconnect(): Promise<void>;
   ping(): Promise<boolean>;
   listIssues(projectIdentifier: string): Promise<HulyIssue[]>;
   upsertDoc(

--- a/tools/huly-os/scripts/backfill-collection-fields.ts
+++ b/tools/huly-os/scripts/backfill-collection-fields.ts
@@ -1,0 +1,172 @@
+// SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017: Backfill missing collection fields for UI visibility
+// Issues created via REST TX or early WS TX lack attachedTo/attachedToClass/collection.
+// Without these, Huly's LiveQuery excludes them from issue list views.
+// Usage: npx tsx scripts/backfill-collection-fields.ts [--dry-run]
+
+import { resolve } from 'node:path';
+
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: resolve(import.meta.dirname ?? '.', '..', '.env') });
+
+const HULY_URL = process.env.HULY_URL ?? 'http://localhost:8087';
+const HULY_EMAIL = process.env.HULY_EMAIL ?? 'ops@unit-talk.local';
+const HULY_PASSWORD = process.env.HULY_PASSWORD ?? 'password';
+const HULY_WORKSPACE = process.env.HULY_WORKSPACE ?? 'unit-talk';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+interface AccountRpcResponse {
+  result?: Record<string, unknown>;
+  error?: { code: string };
+}
+
+async function main(): Promise<void> {
+  console.log(`\nHuly Collection Field Backfill — ${DRY_RUN ? 'DRY-RUN' : 'LIVE'}\n`);
+
+  // Authenticate
+  const loginRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      method: 'login',
+      params: { email: HULY_EMAIL, password: HULY_PASSWORD },
+    }),
+  });
+  const loginBody = (await loginRes.json()) as AccountRpcResponse;
+  if (loginBody.error) throw new Error(`Login failed: ${loginBody.error.code}`);
+  const accountToken = loginBody.result!.token as string;
+  const socialId = String(loginBody.result!.socialId ?? '');
+
+  const wsRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accountToken}` },
+    body: JSON.stringify({ method: 'selectWorkspace', params: { workspaceUrl: HULY_WORKSPACE } }),
+  });
+  const wsBody = (await wsRes.json()) as AccountRpcResponse;
+  if (wsBody.error) throw new Error(`Workspace select failed: ${wsBody.error.code}`);
+  const wsToken = wsBody.result!.token as string;
+  const wsId = wsBody.result!.workspace as string;
+
+  console.log(`Connected to workspace: ${wsId}`);
+
+  // Fetch all issues
+  const issues = await findAll(wsToken, wsId, 'tracker:class:Issue', 500);
+  console.log(`Total issues: ${issues.length}`);
+
+  // Find issues missing collection fields
+  const needsFix = issues.filter(i => !i.attachedTo || !i.attachedToClass || !i.collection);
+
+  console.log(`Issues missing collection fields: ${needsFix.length}`);
+
+  if (needsFix.length === 0) {
+    console.log('Nothing to do.');
+    return;
+  }
+
+  let updated = 0;
+  let errors = 0;
+
+  for (const issue of needsFix) {
+    const issueId = String(issue._id);
+    const space = String(issue.space ?? '');
+    const ident = String(issue.identifier ?? issueId);
+    const operations: Record<string, unknown> = {};
+
+    if (!issue.attachedTo) operations.attachedTo = 'tracker:ids:NoParent';
+    if (!issue.attachedToClass) operations.attachedToClass = 'tracker:class:Issue';
+    if (!issue.collection) operations.collection = 'subIssues';
+    // Also fix kind if it's numeric instead of string
+    if (issue.kind === 0 || issue.kind === undefined || issue.kind === null) {
+      operations.kind = 'tracker:taskTypes:Issue';
+    }
+    // Fix empty rank
+    if (!issue.rank) operations.rank = '0|hzzzzz:';
+    // Add comments if missing
+    if (issue.comments === undefined || issue.comments === null) operations.comments = 0;
+    // Add missing array fields
+    if (!Array.isArray(issue.parents)) operations.parents = [];
+    if (!Array.isArray(issue.childInfo)) operations.childInfo = [];
+    if (!Array.isArray(issue.relations)) operations.relations = [];
+
+    if (Object.keys(operations).length === 0) continue;
+
+    const preview = `${ident} (${issueId}) → ${JSON.stringify(operations)}`;
+    if (DRY_RUN) {
+      console.log(`  [DRY-RUN] ${preview}`);
+      updated++;
+      continue;
+    }
+
+    try {
+      await sendTx(wsToken, wsId, socialId, {
+        _class: 'core:class:TxUpdateDoc',
+        objectId: issueId,
+        objectClass: 'tracker:class:Issue',
+        objectSpace: space,
+        operations,
+      });
+      console.log(`  Updated: ${preview}`);
+      updated++;
+    } catch (err) {
+      console.error(`  ERROR: ${ident}: ${(err as Error).message}`);
+      errors++;
+    }
+  }
+
+  console.log(`\n── Backfill Summary ──`);
+  console.log(`  Updated: ${updated}`);
+  console.log(`  Skipped: ${issues.length - needsFix.length}`);
+  console.log(`  Errors:  ${errors}`);
+}
+
+async function findAll(
+  token: string,
+  wsId: string,
+  cls: string,
+  limit: number
+): Promise<Record<string, unknown>[]> {
+  const opts = JSON.stringify({ limit });
+  const url =
+    `${HULY_URL}/_transactor/api/v1/find-all/${wsId}` +
+    `?class=${encodeURIComponent(cls)}&options=${encodeURIComponent(opts)}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`findAll(${cls}) HTTP ${res.status}`);
+  const body = await res.json();
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.result)) return body.result;
+  if (Array.isArray(body?.value)) return body.value;
+  if (Array.isArray(body?.docs)) return body.docs;
+  return [];
+}
+
+async function sendTx(
+  token: string,
+  wsId: string,
+  socialId: string,
+  fields: Record<string, unknown>
+): Promise<void> {
+  const txId = `tx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tx = {
+    _id: txId,
+    space: 'core:space:Tx',
+    modifiedBy: socialId,
+    modifiedOn: Date.now(),
+    ...fields,
+  };
+
+  const res = await fetch(`${HULY_URL}/_transactor/api/v1/tx/${wsId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(tx),
+  });
+
+  if (!res.ok) {
+    const snippet = await res.text().catch(() => '');
+    throw new Error(`TX HTTP ${res.status}: ${snippet.slice(0, 200)}`);
+  }
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tools/huly-os/scripts/backfill-issue-fields.ts
+++ b/tools/huly-os/scripts/backfill-issue-fields.ts
@@ -1,0 +1,223 @@
+// SPRINT-UI-AUDIT-2026-03-04: Backfill missing status/number/identifier on TX-created issues
+// Usage: npx tsx scripts/backfill-issue-fields.ts [--dry-run]
+
+import { resolve } from 'node:path';
+
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: resolve(import.meta.dirname ?? '.', '..', '.env') });
+
+const HULY_URL = process.env.HULY_URL ?? 'http://localhost:8087';
+const HULY_EMAIL = process.env.HULY_EMAIL ?? 'ops@unit-talk.local';
+const HULY_PASSWORD = process.env.HULY_PASSWORD ?? 'password';
+const HULY_WORKSPACE = process.env.HULY_WORKSPACE ?? 'unit-talk';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+interface AccountRpcResponse {
+  result?: Record<string, unknown>;
+  error?: { code: string };
+}
+
+async function main(): Promise<void> {
+  console.log(`\nHuly Issue Field Backfill — ${DRY_RUN ? 'DRY-RUN' : 'LIVE'}\n`);
+
+  // Authenticate
+  const loginRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      method: 'login',
+      params: { email: HULY_EMAIL, password: HULY_PASSWORD },
+    }),
+  });
+  const loginBody = (await loginRes.json()) as AccountRpcResponse;
+  if (loginBody.error) throw new Error(`Login failed: ${loginBody.error.code}`);
+  const accountToken = loginBody.result!.token as string;
+  const socialId = String(loginBody.result!.socialId ?? '');
+
+  const wsRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accountToken}` },
+    body: JSON.stringify({ method: 'selectWorkspace', params: { workspaceUrl: HULY_WORKSPACE } }),
+  });
+  const wsBody = (await wsRes.json()) as AccountRpcResponse;
+  if (wsBody.error) throw new Error(`Workspace select failed: ${wsBody.error.code}`);
+  const wsToken = wsBody.result!.token as string;
+  const wsId = wsBody.result!.workspace as string;
+
+  console.log(`Connected to workspace: ${wsId}`);
+
+  // Fetch all issues
+  const issues = await findAll(wsToken, wsId, 'tracker:class:Issue', 500);
+  console.log(`Total issues: ${issues.length}`);
+
+  // Fetch all projects
+  const projects = await findAll(wsToken, wsId, 'tracker:class:Project', 20);
+  const projectMap = new Map<string, Record<string, unknown>>();
+  for (const p of projects) {
+    projectMap.set(String(p._id), p);
+  }
+
+  // Group issues by project space
+  const byProject = new Map<string, Record<string, unknown>[]>();
+  for (const issue of issues) {
+    const space = String(issue.space ?? '');
+    if (!byProject.has(space)) byProject.set(space, []);
+    byProject.get(space)!.push(issue);
+  }
+
+  let updated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const [spaceId, projectIssues] of byProject) {
+    const project = projectMap.get(spaceId);
+    if (!project) {
+      console.log(`\nSkipping ${projectIssues.length} issues in unknown space: ${spaceId}`);
+      skipped += projectIssues.length;
+      continue;
+    }
+
+    const projectIdent = String(project.identifier ?? 'UNKNOWN');
+    const defaultStatus = String(project.defaultIssueStatus ?? 'tracker:status:Backlog');
+    let sequence = typeof project.sequence === 'number' ? project.sequence : 0;
+
+    console.log(`\nProject: ${projectIdent} (${spaceId})`);
+    console.log(`  Issues: ${projectIssues.length}, Current sequence: ${sequence}`);
+    console.log(`  Default status: ${defaultStatus}`);
+
+    // Find issues that need backfill (missing status OR number)
+    const needsBackfill = projectIssues.filter(i => !i.status || typeof i.number !== 'number');
+
+    if (needsBackfill.length === 0) {
+      console.log(`  All issues already have required fields — skipping`);
+      skipped += projectIssues.length;
+      continue;
+    }
+
+    console.log(`  Need backfill: ${needsBackfill.length}`);
+
+    // Sort by createdOn to assign numbers in chronological order
+    needsBackfill.sort((a, b) => (Number(a.createdOn) || 0) - (Number(b.createdOn) || 0));
+
+    for (const issue of needsBackfill) {
+      const issueId = String(issue._id);
+      const operations: Record<string, unknown> = {};
+
+      if (!issue.status) {
+        operations.status = defaultStatus;
+      }
+
+      if (typeof issue.number !== 'number') {
+        sequence++;
+        operations.number = sequence;
+        operations.identifier = `${projectIdent}-${sequence}`;
+      }
+
+      if (issue.kind === undefined || issue.kind === null) {
+        operations.kind = 0;
+      }
+
+      if (Object.keys(operations).length === 0) {
+        skipped++;
+        continue;
+      }
+
+      const preview = `${issueId} → ${JSON.stringify(operations)}`;
+      if (DRY_RUN) {
+        console.log(`  [DRY-RUN] ${preview}`);
+        updated++;
+        continue;
+      }
+
+      try {
+        await sendTx(wsToken, wsId, socialId, {
+          _class: 'core:class:TxUpdateDoc',
+          objectId: issueId,
+          objectClass: 'tracker:class:Issue',
+          objectSpace: spaceId,
+          operations,
+        });
+        console.log(`  Updated: ${preview}`);
+        updated++;
+      } catch (err) {
+        console.error(`  ERROR: ${issueId}: ${(err as Error).message}`);
+        errors++;
+      }
+    }
+
+    // Update project sequence counter
+    if (sequence !== (project.sequence ?? 0) && !DRY_RUN) {
+      try {
+        await sendTx(wsToken, wsId, socialId, {
+          _class: 'core:class:TxUpdateDoc',
+          objectId: spaceId,
+          objectClass: 'tracker:class:Project',
+          objectSpace: 'core:space:Space',
+          operations: { sequence },
+        });
+        console.log(`  Updated project sequence → ${sequence}`);
+      } catch (err) {
+        console.error(`  ERROR updating project sequence: ${(err as Error).message}`);
+        errors++;
+      }
+    }
+  }
+
+  console.log(`\n── Backfill Summary ──`);
+  console.log(`  Updated: ${updated}`);
+  console.log(`  Skipped: ${skipped}`);
+  console.log(`  Errors:  ${errors}`);
+}
+
+async function findAll(
+  token: string,
+  wsId: string,
+  cls: string,
+  limit: number
+): Promise<Record<string, unknown>[]> {
+  const opts = JSON.stringify({ limit });
+  const url =
+    `${HULY_URL}/_transactor/api/v1/find-all/${wsId}` +
+    `?class=${encodeURIComponent(cls)}&options=${encodeURIComponent(opts)}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`findAll(${cls}) HTTP ${res.status}`);
+  const body = await res.json();
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.result)) return body.result;
+  if (Array.isArray(body?.value)) return body.value;
+  if (Array.isArray(body?.docs)) return body.docs;
+  return [];
+}
+
+async function sendTx(
+  token: string,
+  wsId: string,
+  socialId: string,
+  fields: Record<string, unknown>
+): Promise<void> {
+  const txId = `tx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tx = {
+    _id: txId,
+    space: 'core:space:Tx',
+    modifiedBy: socialId,
+    modifiedOn: Date.now(),
+    ...fields,
+  };
+
+  const res = await fetch(`${HULY_URL}/_transactor/api/v1/tx/${wsId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(tx),
+  });
+
+  if (!res.ok) {
+    const snippet = await res.text().catch(() => '');
+    throw new Error(`TX HTTP ${res.status}: ${snippet.slice(0, 200)}`);
+  }
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tools/huly-os/scripts/ws-tx-test.ts
+++ b/tools/huly-os/scripts/ws-tx-test.ts
@@ -1,0 +1,258 @@
+// SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017: WebSocket TX test script
+// Creates a test issue via WebSocket TX and verifies it via REST findAll.
+// Usage: npx tsx scripts/ws-tx-test.ts
+
+import { resolve } from 'node:path';
+
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: resolve(import.meta.dirname ?? '.', '..', '.env') });
+
+const HULY_URL = process.env.HULY_URL ?? 'http://localhost:8087';
+const HULY_EMAIL = process.env.HULY_EMAIL ?? 'ops@unit-talk.local';
+const HULY_PASSWORD = process.env.HULY_PASSWORD ?? 'password';
+const HULY_WORKSPACE = process.env.HULY_WORKSPACE ?? 'unit-talk';
+const PROJECT = process.argv[2] ?? 'GAME'; // Default to GAME project (has UI-created issues for comparison)
+
+interface RpcResponse {
+  result?: Record<string, unknown>;
+  error?: { code: string };
+}
+
+async function main(): Promise<void> {
+  const timestamp = new Date().toISOString();
+  const testTitle = `[WS-TEST] ${timestamp}`;
+
+  console.log(`\nWebSocket TX Test — ${timestamp}`);
+  console.log(`Project: ${PROJECT}`);
+  console.log(`URL: ${HULY_URL}\n`);
+
+  // ── Step 1: Authenticate ──
+  console.log('1. Authenticating...');
+  const loginRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      method: 'login',
+      params: { email: HULY_EMAIL, password: HULY_PASSWORD },
+    }),
+  });
+  const loginBody = (await loginRes.json()) as RpcResponse;
+  if (loginBody.error) throw new Error(`Login failed: ${loginBody.error.code}`);
+  const accountToken = loginBody.result!.token as string;
+  const socialId = String(loginBody.result!.socialId ?? '');
+  console.log(`   Logged in as: ${socialId}`);
+
+  // ── Step 2: Select workspace ──
+  console.log('2. Selecting workspace...');
+  const wsRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accountToken}` },
+    body: JSON.stringify({ method: 'selectWorkspace', params: { workspaceUrl: HULY_WORKSPACE } }),
+  });
+  const wsBody = (await wsRes.json()) as RpcResponse;
+  if (wsBody.error) throw new Error(`Workspace select failed: ${wsBody.error.code}`);
+  const workspaceToken = wsBody.result!.token as string;
+  const workspaceId = wsBody.result!.workspace as string;
+  console.log(`   Workspace: ${workspaceId}`);
+
+  // ── Step 3: Find project space ID ──
+  console.log(`3. Finding project "${PROJECT}"...`);
+  const findProjectUrl =
+    `${HULY_URL}/_transactor/api/v1/find-all/${workspaceId}` +
+    `?class=${encodeURIComponent('tracker:class:Project')}&options=${encodeURIComponent(JSON.stringify({ limit: 20 }))}`;
+  const projectRes = await fetch(findProjectUrl, {
+    headers: { Authorization: `Bearer ${workspaceToken}` },
+  });
+  const projectBody = await projectRes.json();
+  const projects: Record<string, unknown>[] = Array.isArray(projectBody)
+    ? projectBody
+    : (projectBody?.value ?? projectBody?.docs ?? []);
+
+  const project = projects.find(p => String(p.identifier) === PROJECT);
+  if (!project) {
+    console.error(
+      `   Project "${PROJECT}" not found. Available: ${projects.map(p => p.identifier).join(', ')}`
+    );
+    process.exit(1);
+  }
+  const spaceId = String(project._id);
+  const projectIdent = String(project.identifier);
+  const defaultStatus = String(project.defaultIssueStatus ?? 'tracker:status:Backlog');
+  let sequence = typeof project.sequence === 'number' ? project.sequence : 0;
+  console.log(`   Found: ${projectIdent} (${spaceId}), sequence=${sequence}`);
+
+  // ── Step 4: Connect WebSocket ──
+  console.log('4. Connecting WebSocket...');
+  const wsUrl = HULY_URL.replace(/^http/, 'ws');
+  const socket = new WebSocket(`${wsUrl}/${workspaceToken}`);
+
+  const connected = await new Promise<boolean>(resolve => {
+    const timeout = setTimeout(() => {
+      console.error('   WebSocket connection timeout');
+      resolve(false);
+    }, 10_000);
+
+    socket.onopen = () => {
+      socket.send(
+        JSON.stringify({ method: 'hello', params: [], id: -1, binary: false, compression: false })
+      );
+    };
+
+    socket.onmessage = async (event: MessageEvent) => {
+      const raw = event.data instanceof Blob ? await event.data.text() : String(event.data);
+      const data = JSON.parse(raw);
+      if (data.id === -1 && data.result === 'hello') {
+        clearTimeout(timeout);
+        console.log(`   Connected! Server version: ${data.serverVersion ?? 'unknown'}`);
+        resolve(true);
+      }
+    };
+
+    socket.onerror = () => {
+      clearTimeout(timeout);
+      resolve(false);
+    };
+  });
+
+  if (!connected) {
+    console.error('   Failed to connect via WebSocket');
+    process.exit(1);
+  }
+
+  // ── Step 5: Send TX via WebSocket ──
+  sequence++;
+  const issueId = `ws-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const issueIdentifier = `${projectIdent}-${sequence}`;
+
+  console.log(`5. Creating issue via WebSocket TX...`);
+  console.log(`   ID: ${issueId}`);
+  console.log(`   Identifier: ${issueIdentifier}`);
+  console.log(`   Title: ${testTitle}`);
+
+  const tx = {
+    _id: `tx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    _class: 'core:class:TxCreateDoc',
+    space: 'core:space:Tx',
+    objectId: issueId,
+    objectClass: 'tracker:class:Issue',
+    objectSpace: spaceId,
+    modifiedBy: socialId,
+    modifiedOn: Date.now(),
+    attributes: {
+      title: testTitle,
+      description: `Created via WebSocket TX test at ${timestamp}`,
+      status: defaultStatus,
+      number: sequence,
+      identifier: issueIdentifier,
+      kind: 'tracker:taskTypes:Issue',
+      priority: 0,
+      component: null,
+      assignee: null,
+      estimation: 0,
+      remainingTime: 0,
+      reportedTime: 0,
+      reports: 0,
+      subIssues: 0,
+      parents: [],
+      childInfo: [],
+      relations: [],
+      dueDate: null,
+      rank: '0|hzzzzz:',
+      comments: 0,
+      // CRITICAL: Collection fields required for LiveQuery visibility
+      attachedTo: 'tracker:ids:NoParent',
+      attachedToClass: 'tracker:class:Issue',
+      collection: 'subIssues',
+    },
+  };
+
+  const txResult = await new Promise<unknown>((resolve, reject) => {
+    const reqId = 1;
+    const timeout = setTimeout(() => reject(new Error('TX timeout (30s)')), 30_000);
+
+    const handler = async (event: MessageEvent) => {
+      const raw = event.data instanceof Blob ? await event.data.text() : String(event.data);
+      const data = JSON.parse(raw);
+      if (data.id === reqId) {
+        clearTimeout(timeout);
+        socket.removeEventListener('message', handler);
+        if (data.error) {
+          reject(new Error(`TX error: ${JSON.stringify(data.error)}`));
+        } else {
+          resolve(data.result);
+        }
+      }
+    };
+    socket.addEventListener('message', handler);
+
+    socket.send(JSON.stringify({ method: 'tx', params: [tx], id: reqId, time: Date.now() }));
+  });
+
+  console.log(`   TX result: ${JSON.stringify(txResult)}`);
+
+  // ── Step 6: Also update project sequence ──
+  console.log(`6. Updating project sequence → ${sequence}...`);
+  const seqTx = {
+    _id: `tx-seq-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    _class: 'core:class:TxUpdateDoc',
+    space: 'core:space:Tx',
+    objectId: spaceId,
+    objectClass: 'tracker:class:Project',
+    objectSpace: 'core:space:Space',
+    modifiedBy: socialId,
+    modifiedOn: Date.now(),
+    operations: { sequence },
+  };
+
+  const seqResult = await new Promise<unknown>((resolve, reject) => {
+    const reqId = 2;
+    const timeout = setTimeout(() => reject(new Error('Seq TX timeout')), 30_000);
+
+    const handler = async (event: MessageEvent) => {
+      const raw = event.data instanceof Blob ? await event.data.text() : String(event.data);
+      const data = JSON.parse(raw);
+      if (data.id === reqId) {
+        clearTimeout(timeout);
+        socket.removeEventListener('message', handler);
+        resolve(data.result);
+      }
+    };
+    socket.addEventListener('message', handler);
+
+    socket.send(JSON.stringify({ method: 'tx', params: [seqTx], id: reqId, time: Date.now() }));
+  });
+  console.log(`   Seq TX result: ${JSON.stringify(seqResult)}`);
+
+  // ── Step 7: Verify via REST findAll ──
+  console.log('7. Verifying issue exists via REST findAll...');
+  const findUrl =
+    `${HULY_URL}/_transactor/api/v1/find-all/${workspaceId}` +
+    `?class=${encodeURIComponent('tracker:class:Issue')}&options=${encodeURIComponent(JSON.stringify({ limit: 500 }))}`;
+  const findRes = await fetch(findUrl, { headers: { Authorization: `Bearer ${workspaceToken}` } });
+  const findBody = await findRes.json();
+  const issues: Record<string, unknown>[] = Array.isArray(findBody)
+    ? findBody
+    : (findBody?.value ?? findBody?.docs ?? []);
+
+  const found = issues.find(i => String(i._id) === issueId);
+  if (found) {
+    console.log(`   FOUND: ${found.identifier} — "${found.title}"`);
+    console.log(`   Status: ${found.status}, Number: ${found.number}`);
+  } else {
+    console.error(`   NOT FOUND in findAll results (${issues.length} total issues)`);
+  }
+
+  // ── Step 8: Close ──
+  socket.close();
+  console.log('\n8. WebSocket closed.');
+  console.log(`\n── Result ──`);
+  console.log(`Issue created: ${issueIdentifier} — "${testTitle}"`);
+  console.log(`Verify in UI: ${HULY_URL}/workbench/${HULY_WORKSPACE}/tracker/${issueIdentifier}`);
+  console.log(`Or check project issues list in Huly Tracker.`);
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **HulyAdapter** now sends TX over WebSocket (same protocol as Huly frontend) instead of REST-only, entering the LiveQuery broadcast pipeline so issues render in the UI
- Added three critical **collection fields** (`attachedTo`, `attachedToClass`, `collection`) to all issue creates — these are what Huly's LiveQuery uses to filter the issue list query
- Backfilled 140 existing issues with the missing fields — all now visible in the UI

## Root Cause

Issues created via REST TX API (or WebSocket TX without collection fields) were stored in CockroachDB but excluded from the frontend's LiveQuery subscription. The frontend queries issues filtering on `attachedTo === 'tracker:ids:NoParent'` for top-level issues. Without that field, issues were invisible.

## Before/After

| Project | Before | After |
|---------|--------|-------|
| UT | 0 issues visible | 134 issues visible (2 In Progress + 132 Backlog) |
| GAME | 4 issues visible (UI-created only) | 5 issues visible (including WS-created GAME-8) |

## Changes

| File | Change |
|------|--------|
| `daemon/adapters/huly-adapter.ts` | WebSocket TX primary + REST fallback, collection fields on creates |
| `daemon/adapters/types.ts` | Added `disconnect()` to `IHulyAdapter` |
| `scripts/ws-tx-test.ts` | Standalone WebSocket TX verification script |
| `scripts/backfill-collection-fields.ts` | Backfill `attachedTo`/`attachedToClass`/`collection` on existing issues |
| `scripts/backfill-issue-fields.ts` | Earlier status/number/identifier backfill |

## Test plan

- [x] Type check passes (`npx tsc --noEmit`)
- [x] ESLint clean on all changed files
- [x] `ws-tx-test.ts` creates GAME-8 via WebSocket — stored in DB
- [x] Playwright: GAME-8 visible in UI issues list (Backlog 5)
- [x] Playwright: UT project shows 134 issues after backfill (was 0)
- [x] No trigger errors in transactor logs

[SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017]

🤖 Generated with [Claude Code](https://claude.com/claude-code)