### PR TITLE
feat(huly-os): P0 enhancements — bidirectional sync, sprint closeout, doc fields

### DIFF
--- a/tools/huly-os/daemon/adapters/huly-adapter.ts
+++ b/tools/huly-os/daemon/adapters/huly-adapter.ts
@@ -372,9 +372,13 @@ export class HulyAdapter implements IHulyAdapter {
       objectSpace: 'core:space:Space',
       attributes: {
         name,
+        title: name,
         description: `${name} — auto-created by HULY-OS operator`,
+        type: 'document:spaceType:DefaultTeamspaceType',
+        autoJoin: true,
         private: false,
         archived: false,
+        owners: [this.socialId],
         members: [this.socialId],
       },
     });
@@ -593,6 +597,15 @@ export class HulyAdapter implements IHulyAdapter {
           attributes: {
             title: docTitle,
             content: markdownContent,
+            // Required for Documents LiveQuery visibility (same pattern as issues)
+            parent: 'document:ids:NoParent',
+            rank: '0|hzzzzz:',
+            attachments: 0,
+            comments: 0,
+            docUpdateMessages: 0,
+            embeddings: 0,
+            labels: 0,
+            references: 0,
           },
         });
 

--- a/tools/huly-os/daemon/operator.ts
+++ b/tools/huly-os/daemon/operator.ts
@@ -7,6 +7,7 @@ import { resolve } from 'node:path';
 
 import { GitHubAdapter } from './adapters/github-adapter.js';
 import { HulyAdapter } from './adapters/huly-adapter.js';
+import { HULY_STATUS } from './adapters/types.js';
 import { AuditLogger } from './audit-log.js';
 import { loadConfig, REPO_ROOT } from './config.js';
 import { evaluateSprints, applySprintTransitions, branchToSprintId } from './sprint-manager.js';
@@ -451,6 +452,68 @@ export async function runOperatorCycle(opts?: {
             `Drift issue creation failed: ${sprintId} — ${(err as Error).message}`
           );
         }
+      }
+    }
+  }
+
+  // ── Phase 6: Bidirectional GitHub↔Huly sync ─────────────────────────
+  // [ENH][P0] Auto-transition issues based on PR state:
+  //   - Merged PR → linked issue to Done
+  //   - Open PR → linked issue to In Progress
+
+  // Build issue lookup by identifier (e.g. "UT-42")
+  const issueByIdent = new Map<string, HulyIssue>();
+  for (const issue of hulyIssues) {
+    if (issue.identifier) issueByIdent.set(issue.identifier, issue);
+  }
+
+  // Merged PR → linked issues to Done
+  for (const pr of mergedPRs) {
+    for (const ref of pr.linkedIssueRefs) {
+      const issue = issueByIdent.get(ref);
+      if (!issue || issue.status === 'Done' || issue.status === 'Cancelled') continue;
+      // Skip meta-issues (sprints, incidents, drift, enhancements)
+      if (/^\[(SPRINT|INCIDENT|DRIFT|ENH)\]/.test(issue.title)) continue;
+
+      const key = dedupKey('autoresolve', ref, pr.number);
+      if (alreadySeen(key)) continue;
+
+      try {
+        await huly.updateIssueStatus(issue.id, HULY_STATUS.Done, issue.project);
+        await huly.addComment(
+          issue.id,
+          `**Auto-resolved:** PR #${pr.number} merged → Done\n\nPR: ${pr.url}`
+        );
+        result.actions.statusTransitions++;
+        console.log(`[operator] Auto-resolved: ${ref} → Done (PR #${pr.number} merged)`);
+      } catch (err) {
+        result.errors.push(`Auto-resolve failed: ${ref} — ${(err as Error).message}`);
+      }
+    }
+  }
+
+  // Open PR → linked issues to In Progress
+  for (const pr of openPRs) {
+    for (const ref of pr.linkedIssueRefs) {
+      const issue = issueByIdent.get(ref);
+      if (!issue) continue;
+      if (issue.status === 'In Progress' || issue.status === 'Done' || issue.status === 'Cancelled')
+        continue;
+      if (/^\[(SPRINT|INCIDENT|DRIFT|ENH)\]/.test(issue.title)) continue;
+
+      const key = dedupKey('autoprogress', ref, pr.number);
+      if (alreadySeen(key)) continue;
+
+      try {
+        await huly.updateIssueStatus(issue.id, HULY_STATUS.InProgress, issue.project);
+        await huly.addComment(
+          issue.id,
+          `**Auto-transitioned:** PR #${pr.number} opened → In Progress\n\nPR: ${pr.url}`
+        );
+        result.actions.statusTransitions++;
+        console.log(`[operator] Auto-progress: ${ref} → In Progress (PR #${pr.number} open)`);
+      } catch (err) {
+        result.errors.push(`Auto-progress failed: ${ref} — ${(err as Error).message}`);
       }
     }
   }

--- a/tools/huly-os/package.json
+++ b/tools/huly-os/package.json
@@ -17,6 +17,7 @@
     "huly:report:weekly": "tsx daemon/operator-cli.ts report-weekly",
     "huly:backfill": "tsx scripts/backfill-huly-issues.ts",
     "huly:publish-os": "tsx scripts/publish-os-docs.ts",
+    "sprint:close": "tsx scripts/sprint-close.ts",
     "type-check": "tsc --noEmit",
     "lint": "eslint . --ext .ts"
   },

--- a/tools/huly-os/scripts/backfill-doc-fields.ts
+++ b/tools/huly-os/scripts/backfill-doc-fields.ts
@@ -1,0 +1,235 @@
+// Backfill missing Document/Teamspace fields for UI visibility
+// Usage: npx tsx scripts/backfill-doc-fields.ts
+
+import { resolve } from 'node:path';
+
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: resolve(import.meta.dirname ?? '.', '..', '.env') });
+
+const HULY_URL = process.env.HULY_URL ?? 'http://localhost:8087';
+const HULY_EMAIL = process.env.HULY_EMAIL ?? 'ops@unit-talk.local';
+const HULY_PASSWORD = process.env.HULY_PASSWORD ?? 'password';
+const HULY_WORKSPACE = process.env.HULY_WORKSPACE ?? 'unit-talk';
+
+interface RpcResponse {
+  result?: Record<string, unknown>;
+  error?: { code: string };
+}
+
+async function main(): Promise<void> {
+  console.log('\nDocument/Teamspace Field Backfill\n');
+
+  // Authenticate
+  const loginRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      method: 'login',
+      params: { email: HULY_EMAIL, password: HULY_PASSWORD },
+    }),
+  });
+  const loginBody = (await loginRes.json()) as RpcResponse;
+  if (loginBody.error) throw new Error(`Login failed: ${loginBody.error.code}`);
+  const accountToken = loginBody.result!.token as string;
+  const socialId = String(loginBody.result!.socialId ?? '');
+
+  const wsRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accountToken}` },
+    body: JSON.stringify({ method: 'selectWorkspace', params: { workspaceUrl: HULY_WORKSPACE } }),
+  });
+  const wsBody = (await wsRes.json()) as RpcResponse;
+  if (wsBody.error) throw new Error(`Workspace select failed: ${wsBody.error.code}`);
+  const workspaceToken = wsBody.result!.token as string;
+  const workspaceId = wsBody.result!.workspace as string;
+
+  // Connect WebSocket
+  const wsUrl = HULY_URL.replace(/^http/, 'ws');
+  const socket = new WebSocket(`${wsUrl}/${workspaceToken}`);
+  const connected = await new Promise<boolean>(resolve => {
+    const timeout = setTimeout(() => resolve(false), 10_000);
+    socket.onopen = () => {
+      socket.send(
+        JSON.stringify({ method: 'hello', params: [], id: -1, binary: false, compression: false })
+      );
+    };
+    socket.onmessage = async (event: MessageEvent) => {
+      const raw = event.data instanceof Blob ? await event.data.text() : String(event.data);
+      const data = JSON.parse(raw);
+      if (data.id === -1) {
+        clearTimeout(timeout);
+        resolve(true);
+      }
+    };
+    socket.onerror = () => {
+      clearTimeout(timeout);
+      resolve(false);
+    };
+  });
+  if (!connected) throw new Error('WebSocket connection failed');
+  console.log('Connected.\n');
+
+  let reqId = 0;
+
+  // ── Fix Teamspaces ──
+  console.log('=== Teamspaces ===');
+  const teamspaces = await findAll(workspaceToken, workspaceId, 'document:class:Teamspace', 50);
+  for (const ts of teamspaces) {
+    const ops: Record<string, unknown> = {};
+    if (!ts.type) ops.type = 'document:spaceType:DefaultTeamspaceType';
+    if (!ts.title) ops.title = String(ts.name);
+    if (ts.autoJoin === undefined) ops.autoJoin = true;
+    if (!ts.owners) ops.owners = [socialId];
+
+    if (Object.keys(ops).length === 0) {
+      console.log(`  OK: "${ts.name}" (${ts._id})`);
+      continue;
+    }
+
+    reqId++;
+    await wsSend(
+      socket,
+      {
+        _id: `tx-fix-ts-${Date.now()}-${reqId}`,
+        space: 'core:space:Tx',
+        _class: 'core:class:TxUpdateDoc',
+        objectId: String(ts._id),
+        objectClass: 'document:class:Teamspace',
+        objectSpace: 'core:space:Space',
+        modifiedBy: socialId,
+        modifiedOn: Date.now(),
+        operations: ops,
+      },
+      reqId
+    );
+    console.log(`  Fixed: "${ts.name}" → ${JSON.stringify(ops)}`);
+  }
+
+  // ── Fix Documents ──
+  console.log('\n=== Documents ===');
+  const docs = await findAll(workspaceToken, workspaceId, 'document:class:Document', 200);
+  let fixed = 0;
+
+  for (const doc of docs) {
+    const ops: Record<string, unknown> = {};
+    if (!doc.parent) ops.parent = 'document:ids:NoParent';
+    if (!doc.rank) ops.rank = '0|hzzzzz:';
+    if (doc.attachments === undefined) ops.attachments = 0;
+    if (doc.comments === undefined) ops.comments = 0;
+    if (doc.docUpdateMessages === undefined) ops.docUpdateMessages = 0;
+    if (doc.embeddings === undefined) ops.embeddings = 0;
+    if (doc.labels === undefined) ops.labels = 0;
+    if (doc.references === undefined) ops.references = 0;
+
+    if (Object.keys(ops).length === 0) {
+      console.log(`  OK: "${doc.title}" (${doc._id})`);
+      continue;
+    }
+
+    reqId++;
+    await wsSend(
+      socket,
+      {
+        _id: `tx-fix-doc-${Date.now()}-${reqId}`,
+        space: 'core:space:Tx',
+        _class: 'core:class:TxUpdateDoc',
+        objectId: String(doc._id),
+        objectClass: 'document:class:Document',
+        objectSpace: String(doc.space),
+        modifiedBy: socialId,
+        modifiedOn: Date.now(),
+        operations: ops,
+      },
+      reqId
+    );
+    console.log(`  Fixed: "${doc.title}" → ${JSON.stringify(ops)}`);
+    fixed++;
+  }
+
+  // ── Create a fresh test doc with all fields ──
+  console.log('\n=== Creating test doc with all fields ===');
+  const opsTeamspace = teamspaces.find(t => String(t.name) === 'Operations');
+  if (opsTeamspace) {
+    reqId++;
+    const testDocId = `doc-test-complete-${Date.now()}`;
+    await wsSend(
+      socket,
+      {
+        _id: `tx-doc-test-${Date.now()}`,
+        space: 'core:space:Tx',
+        _class: 'core:class:TxCreateDoc',
+        objectId: testDocId,
+        objectClass: 'document:class:Document',
+        objectSpace: String(opsTeamspace._id),
+        modifiedBy: socialId,
+        modifiedOn: Date.now(),
+        attributes: {
+          title: `[DOC-TEST-COMPLETE] ${new Date().toISOString()}`,
+          content:
+            '# Complete Test Document\n\nCreated with all required fields for UI visibility.',
+          parent: 'document:ids:NoParent',
+          rank: '0|hzzzzz:',
+          attachments: 0,
+          comments: 0,
+          docUpdateMessages: 0,
+          embeddings: 0,
+          labels: 0,
+          references: 0,
+        },
+      },
+      reqId
+    );
+    console.log(`  Created: ${testDocId}`);
+  }
+
+  socket.close();
+  console.log(`\nDone. Fixed ${fixed} documents.`);
+}
+
+async function wsSend(
+  socket: WebSocket,
+  tx: Record<string, unknown>,
+  id: number
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`TX timeout for #${id}`)), 30_000);
+    const handler = async (event: MessageEvent) => {
+      const raw = event.data instanceof Blob ? await event.data.text() : String(event.data);
+      const data = JSON.parse(raw);
+      if (data.id === id) {
+        clearTimeout(timeout);
+        socket.removeEventListener('message', handler);
+        if (data.error) reject(new Error(`TX error: ${JSON.stringify(data.error)}`));
+        else resolve(data.result);
+      }
+    };
+    socket.addEventListener('message', handler);
+    socket.send(JSON.stringify({ method: 'tx', params: [tx], id, time: Date.now() }));
+  });
+}
+
+async function findAll(
+  token: string,
+  wsId: string,
+  cls: string,
+  limit: number
+): Promise<Record<string, unknown>[]> {
+  const opts = JSON.stringify({ limit });
+  const url =
+    `${HULY_URL}/_transactor/api/v1/find-all/${wsId}` +
+    `?class=${encodeURIComponent(cls)}&options=${encodeURIComponent(opts)}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`findAll(${cls}) HTTP ${res.status}`);
+  const body = await res.json();
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.result)) return body.result;
+  if (Array.isArray(body?.value)) return body.value;
+  if (Array.isArray(body?.docs)) return body.docs;
+  return [];
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tools/huly-os/scripts/doc-visibility-test.ts
+++ b/tools/huly-os/scripts/doc-visibility-test.ts
@@ -1,0 +1,241 @@
+// P0 Enhancement 3: Test Document visibility in Huly UI
+// Creates a test document via HulyAdapter.upsertDoc() and verifies it exists.
+// Usage: npx tsx scripts/doc-visibility-test.ts
+
+import { resolve } from 'node:path';
+
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: resolve(import.meta.dirname ?? '.', '..', '.env') });
+
+const HULY_URL = process.env.HULY_URL ?? 'http://localhost:8087';
+const HULY_EMAIL = process.env.HULY_EMAIL ?? 'ops@unit-talk.local';
+const HULY_PASSWORD = process.env.HULY_PASSWORD ?? 'password';
+const HULY_WORKSPACE = process.env.HULY_WORKSPACE ?? 'unit-talk';
+const TEAMSPACE = process.env.HULY_TEAMSPACE ?? 'Operations';
+
+interface RpcResponse {
+  result?: Record<string, unknown>;
+  error?: { code: string };
+}
+
+async function main(): Promise<void> {
+  const timestamp = new Date().toISOString();
+  console.log(`\nDocument Visibility Test — ${timestamp}`);
+  console.log(`URL: ${HULY_URL}`);
+  console.log(`Teamspace: ${TEAMSPACE}\n`);
+
+  // ── Authenticate ──
+  console.log('1. Authenticating...');
+  const loginRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      method: 'login',
+      params: { email: HULY_EMAIL, password: HULY_PASSWORD },
+    }),
+  });
+  const loginBody = (await loginRes.json()) as RpcResponse;
+  if (loginBody.error) throw new Error(`Login failed: ${loginBody.error.code}`);
+  const accountToken = loginBody.result!.token as string;
+  const socialId = String(loginBody.result!.socialId ?? '');
+
+  console.log('2. Selecting workspace...');
+  const wsRes = await fetch(`${HULY_URL}/_accounts/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accountToken}` },
+    body: JSON.stringify({ method: 'selectWorkspace', params: { workspaceUrl: HULY_WORKSPACE } }),
+  });
+  const wsBody = (await wsRes.json()) as RpcResponse;
+  if (wsBody.error) throw new Error(`Workspace select failed: ${wsBody.error.code}`);
+  const workspaceToken = wsBody.result!.token as string;
+  const workspaceId = wsBody.result!.workspace as string;
+
+  // ── Connect WebSocket ──
+  console.log('3. Connecting WebSocket...');
+  const wsUrl = HULY_URL.replace(/^http/, 'ws');
+  const socket = new WebSocket(`${wsUrl}/${workspaceToken}`);
+
+  const connected = await new Promise<boolean>(resolve => {
+    const timeout = setTimeout(() => resolve(false), 10_000);
+    socket.onopen = () => {
+      socket.send(
+        JSON.stringify({ method: 'hello', params: [], id: -1, binary: false, compression: false })
+      );
+    };
+    socket.onmessage = async (event: MessageEvent) => {
+      const raw = event.data instanceof Blob ? await event.data.text() : String(event.data);
+      const data = JSON.parse(raw);
+      if (data.id === -1) {
+        clearTimeout(timeout);
+        resolve(true);
+      }
+    };
+    socket.onerror = () => {
+      clearTimeout(timeout);
+      resolve(false);
+    };
+  });
+  if (!connected) throw new Error('WebSocket connection failed');
+  console.log('   Connected.\n');
+
+  let reqId = 0;
+
+  // ── Find or create teamspace ──
+  console.log(`4. Resolving teamspace "${TEAMSPACE}"...`);
+  const teamspaces = await findAll(workspaceToken, workspaceId, 'document:class:Teamspace', 50);
+  let teamspaceId = teamspaces.find(t => String(t.name) === TEAMSPACE)?._id as string | undefined;
+
+  if (!teamspaceId) {
+    console.log(`   Creating teamspace "${TEAMSPACE}"...`);
+    teamspaceId = `teamspace-${Date.now()}`;
+    reqId++;
+    const tx = buildTx(socialId, {
+      _class: 'core:class:TxCreateDoc',
+      objectId: teamspaceId,
+      objectClass: 'document:class:Teamspace',
+      objectSpace: 'core:space:Space',
+      attributes: {
+        name: TEAMSPACE,
+        description: `${TEAMSPACE} — auto-created by doc-visibility-test`,
+        private: false,
+        archived: false,
+        members: [socialId],
+      },
+    });
+    await wsSend(socket, tx, reqId);
+    console.log(`   Created: ${teamspaceId}`);
+  } else {
+    teamspaceId = String(teamspaceId);
+    console.log(`   Found: ${teamspaceId}`);
+  }
+
+  // ── Fetch existing docs for comparison ──
+  console.log('\n5. Listing existing documents...');
+  const existingDocs = await findAll(workspaceToken, workspaceId, 'document:class:Document', 100);
+  console.log(`   Found ${existingDocs.length} documents`);
+  for (const doc of existingDocs.slice(0, 5)) {
+    console.log(`   - "${doc.title}" (${doc._id}) space=${doc.space}`);
+    // Show all fields for first doc to understand structure
+    if (doc === existingDocs[0]) {
+      const keys = Object.keys(doc).sort();
+      console.log(`     Fields: ${keys.join(', ')}`);
+    }
+  }
+
+  // ── Create test document ──
+  const docTitle = `[DOC-TEST] ${timestamp}`;
+  const docContent = `# Document Visibility Test\n\nCreated: ${timestamp}\n\nThis document was created via WebSocket TX to test Huly Documents UI visibility.`;
+  const docId = `doc-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  console.log(`\n6. Creating test document...`);
+  console.log(`   Title: ${docTitle}`);
+  console.log(`   ID: ${docId}`);
+  console.log(`   Space: ${teamspaceId}`);
+
+  reqId++;
+  const docTx = buildTx(socialId, {
+    _class: 'core:class:TxCreateDoc',
+    objectId: docId,
+    objectClass: 'document:class:Document',
+    objectSpace: teamspaceId,
+    attributes: {
+      title: docTitle,
+      content: docContent,
+    },
+  });
+  await wsSend(socket, docTx, reqId);
+  console.log('   Document created via WebSocket TX.');
+
+  // ── Verify via REST ──
+  console.log('\n7. Verifying via REST findAll...');
+  const allDocs = await findAll(workspaceToken, workspaceId, 'document:class:Document', 200);
+  const found = allDocs.find(d => String(d._id) === docId);
+  if (found) {
+    console.log(`   FOUND: "${found.title}" (${found._id})`);
+    console.log(`   All fields: ${JSON.stringify(found, null, 2)}`);
+  } else {
+    console.log(`   NOT FOUND in ${allDocs.length} documents.`);
+  }
+
+  // ── Also compare with a UI-created doc if one exists ──
+  if (existingDocs.length > 0) {
+    const uiDoc = existingDocs[0];
+    console.log('\n8. Comparing with existing document (likely UI-created):');
+    console.log(`   Existing: ${JSON.stringify(uiDoc, null, 2)}`);
+    if (found) {
+      const existingKeys = new Set(Object.keys(uiDoc));
+      const newKeys = new Set(Object.keys(found));
+      const missingInNew = [...existingKeys].filter(k => !newKeys.has(k));
+      const extraInNew = [...newKeys].filter(k => !existingKeys.has(k));
+      if (missingInNew.length > 0) {
+        console.log(`\n   MISSING in TX doc (present in existing): ${missingInNew.join(', ')}`);
+      }
+      if (extraInNew.length > 0) {
+        console.log(`   EXTRA in TX doc (not in existing): ${extraInNew.join(', ')}`);
+      }
+    }
+  }
+
+  socket.close();
+  console.log('\n9. Done.');
+  console.log(`\nVerify in Huly UI: ${HULY_URL}/workbench/${HULY_WORKSPACE}/documents`);
+  console.log('Check if the test document appears in the Documents page.');
+}
+
+function buildTx(socialId: string, fields: Record<string, unknown>): Record<string, unknown> {
+  return {
+    _id: `tx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    space: 'core:space:Tx',
+    modifiedBy: socialId,
+    modifiedOn: Date.now(),
+    ...fields,
+  };
+}
+
+async function wsSend(
+  socket: WebSocket,
+  tx: Record<string, unknown>,
+  id: number
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`TX timeout for #${id}`)), 30_000);
+    const handler = async (event: MessageEvent) => {
+      const raw = event.data instanceof Blob ? await event.data.text() : String(event.data);
+      const data = JSON.parse(raw);
+      if (data.id === id) {
+        clearTimeout(timeout);
+        socket.removeEventListener('message', handler);
+        if (data.error) reject(new Error(`TX error: ${JSON.stringify(data.error)}`));
+        else resolve(data.result);
+      }
+    };
+    socket.addEventListener('message', handler);
+    socket.send(JSON.stringify({ method: 'tx', params: [tx], id, time: Date.now() }));
+  });
+}
+
+async function findAll(
+  token: string,
+  wsId: string,
+  cls: string,
+  limit: number
+): Promise<Record<string, unknown>[]> {
+  const opts = JSON.stringify({ limit });
+  const url =
+    `${HULY_URL}/_transactor/api/v1/find-all/${wsId}` +
+    `?class=${encodeURIComponent(cls)}&options=${encodeURIComponent(opts)}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`findAll(${cls}) HTTP ${res.status}`);
+  const body = await res.json();
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.result)) return body.result;
+  if (Array.isArray(body?.value)) return body.value;
+  if (Array.isArray(body?.docs)) return body.docs;
+  return [];
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tools/huly-os/scripts/sprint-close.ts
+++ b/tools/huly-os/scripts/sprint-close.ts
@@ -1,0 +1,217 @@
+// [ENH][P0] Sprint closeout writes back to Huly (Done + proof links)
+// Updates all sprint-related Huly issues to Done, attaches proof artifact links,
+// and publishes a closeout document.
+// Usage: npx tsx scripts/sprint-close.ts <SPRINT-ID> [--dry-run]
+
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: resolve(import.meta.dirname ?? '.', '..', '.env') });
+
+import { HulyAdapter } from '../daemon/adapters/huly-adapter.js';
+import { HULY_STATUS } from '../daemon/adapters/types.js';
+import { AuditLogger } from '../daemon/audit-log.js';
+import { loadConfig, REPO_ROOT } from '../daemon/config.js';
+
+import type { HulyIssue } from '../daemon/adapters/types.js';
+
+async function main(): Promise<void> {
+  const sprintId = process.argv[2];
+  const dryRun = process.argv.includes('--dry-run');
+
+  if (!sprintId) {
+    console.error('Usage: npx tsx scripts/sprint-close.ts <SPRINT-ID> [--dry-run]');
+    console.error('Example: npx tsx scripts/sprint-close.ts SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017');
+    process.exit(1);
+  }
+
+  console.log(`\nSprint Closeout — ${sprintId} ${dryRun ? '(DRY-RUN)' : '(LIVE)'}\n`);
+
+  // Check proof directory
+  const proofDir = resolve(REPO_ROOT, 'out', 'sprints', sprintId);
+  const proofExists = existsSync(proofDir);
+  console.log(`Proof directory: ${proofDir} — ${proofExists ? 'EXISTS' : 'NOT FOUND'}`);
+
+  // Connect to Huly
+  const config = loadConfig();
+  const audit = new AuditLogger();
+  const huly = new HulyAdapter(config, audit);
+  await huly.connect();
+  console.log('Connected to Huly.\n');
+
+  // List all issues
+  const allIssues = await huly.listIssues(config.HULY_PROJECT);
+  console.log(`Total issues: ${allIssues.length}`);
+
+  // Find [SPRINT] parent issue
+  const sprintTitle = `[SPRINT] ${sprintId}`;
+  const sprintIssue = allIssues.find(i => i.title === sprintTitle);
+  if (!sprintIssue) {
+    console.error(`\nSprint issue not found: "${sprintTitle}"`);
+    console.error('Available sprint issues:');
+    for (const i of allIssues.filter(i => i.title.startsWith('[SPRINT]'))) {
+      console.error(`  - ${i.identifier}: ${i.title} (${i.status})`);
+    }
+    process.exit(1);
+  }
+  console.log(
+    `Sprint issue: ${sprintIssue.identifier} — ${sprintIssue.title} (${sprintIssue.status})`
+  );
+
+  // Find related issues: title contains SPRINT-ID, or task issues like "Plan — SPRINT-ID"
+  const sprintIdUpper = sprintId.toUpperCase();
+  const relatedIssues = allIssues.filter(i => {
+    if (i.id === sprintIssue.id) return false; // exclude parent
+    return (
+      i.title.includes(sprintId) ||
+      i.title.includes(sprintIdUpper) ||
+      i.title.toUpperCase().includes(sprintIdUpper)
+    );
+  });
+  console.log(`Related issues: ${relatedIssues.length}\n`);
+
+  // Transition non-Done issues
+  const closedIssues: HulyIssue[] = [];
+  const skippedIssues: HulyIssue[] = [];
+  const proofNote = proofExists
+    ? `Proof: \`${proofDir.replace(REPO_ROOT + '/', '').replace(REPO_ROOT + '\\', '')}\``
+    : 'Proof: not found (generate before final closeout)';
+
+  for (const issue of relatedIssues) {
+    if (issue.status === 'Done' || issue.status === 'Cancelled') {
+      skippedIssues.push(issue);
+      console.log(`  SKIP: ${issue.identifier} — ${issue.title} (already ${issue.status})`);
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(
+        `  [DRY-RUN] Would close: ${issue.identifier} — ${issue.title} (${issue.status})`
+      );
+      closedIssues.push(issue);
+      continue;
+    }
+
+    try {
+      await huly.updateIssueStatus(issue.id, HULY_STATUS.Done, issue.project);
+      await huly.addComment(
+        issue.id,
+        `**Sprint closed:** ${sprintId}\n\n${proofNote}\nClosed at: ${new Date().toISOString()}`
+      );
+      closedIssues.push(issue);
+      console.log(`  CLOSED: ${issue.identifier} — ${issue.title}`);
+    } catch (err) {
+      console.error(`  ERROR: ${issue.identifier} — ${(err as Error).message}`);
+    }
+  }
+
+  // Close the [SPRINT] parent issue itself
+  if (sprintIssue.status !== 'Done' && sprintIssue.status !== 'Cancelled') {
+    if (dryRun) {
+      console.log(`\n  [DRY-RUN] Would close sprint issue: ${sprintIssue.identifier}`);
+    } else {
+      try {
+        await huly.updateIssueStatus(sprintIssue.id, HULY_STATUS.Done, sprintIssue.project);
+
+        // Build closeout summary comment
+        const summary = [
+          `**Sprint Closeout — ${sprintId}**`,
+          '',
+          `Closed at: ${new Date().toISOString()}`,
+          `${proofNote}`,
+          '',
+          `**Issues closed (${closedIssues.length}):**`,
+          ...closedIssues.map(i => `- ${i.identifier}: ${i.title}`),
+          '',
+          `**Already done/skipped (${skippedIssues.length}):**`,
+          ...skippedIssues.map(i => `- ${i.identifier}: ${i.title} (${i.status})`),
+        ].join('\n');
+
+        await huly.addComment(sprintIssue.id, summary);
+        console.log(`\n  CLOSED sprint issue: ${sprintIssue.identifier}`);
+      } catch (err) {
+        console.error(`\n  ERROR closing sprint issue: ${(err as Error).message}`);
+      }
+    }
+  } else {
+    console.log(`\n  Sprint issue already ${sprintIssue.status}`);
+  }
+
+  // Publish closeout document
+  if (!dryRun) {
+    const closeoutMd = buildCloseoutDocument(
+      sprintId,
+      closedIssues,
+      skippedIssues,
+      proofDir,
+      proofExists
+    );
+    try {
+      const docTitle = `Sprint Closeout — ${sprintId}`;
+      const { id, created } = await huly.upsertDoc(config.HULY_TEAMSPACE, docTitle, closeoutMd);
+      console.log(`\n  Closeout document ${created ? 'created' : 'updated'}: ${id}`);
+    } catch (err) {
+      console.warn(`  Document publish failed (non-fatal): ${(err as Error).message}`);
+    }
+  }
+
+  await huly.disconnect();
+
+  // Summary
+  console.log(`\n── Sprint Closeout Summary ──`);
+  console.log(`  Sprint: ${sprintId}`);
+  console.log(`  Mode: ${dryRun ? 'DRY-RUN' : 'LIVE'}`);
+  console.log(`  Issues closed: ${closedIssues.length}`);
+  console.log(`  Issues skipped: ${skippedIssues.length}`);
+  console.log(`  Proof exists: ${proofExists}`);
+}
+
+function buildCloseoutDocument(
+  sprintId: string,
+  closed: HulyIssue[],
+  skipped: HulyIssue[],
+  proofDir: string,
+  proofExists: boolean
+): string {
+  const now = new Date().toISOString();
+  let md = `# Sprint Closeout — ${sprintId}\n\n`;
+  md += `**Date:** ${now.slice(0, 10)}\n`;
+  md += `**Generated:** ${now}\n`;
+  md += `**Proof:** ${proofExists ? proofDir : 'Not found'}\n\n`;
+
+  md += `## Issues Closed (${closed.length})\n\n`;
+  if (closed.length === 0) {
+    md += '_No issues closed._\n\n';
+  } else {
+    md += '| Identifier | Title |\n';
+    md += '|------------|-------|\n';
+    for (const i of closed) {
+      md += `| ${i.identifier} | ${i.title} |\n`;
+    }
+    md += '\n';
+  }
+
+  md += `## Already Done/Skipped (${skipped.length})\n\n`;
+  if (skipped.length === 0) {
+    md += '_No issues skipped._\n\n';
+  } else {
+    for (const i of skipped) {
+      md += `- ${i.identifier}: ${i.title} (${i.status})\n`;
+    }
+    md += '\n';
+  }
+
+  md += `## Proof Artifacts\n\n`;
+  md += proofExists
+    ? `Proof bundle: \`${proofDir}\`\n`
+    : '_Proof bundle not found. Generate before final closeout._\n';
+
+  return md;
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **UT-151 — Bidirectional GitHub↔Huly sync:** Adds Phase 6 to operator cycle — merged PRs auto-transition linked issues to Done, open PRs transition to In Progress. Skips meta-issues ([SPRINT], [INCIDENT], [DRIFT], [ENH]).
- **UT-152 — Sprint closeout writes back to Huly:** New `sprint:close` CLI that finds sprint parent + related issues, transitions all to Done with proof links, and publishes a closeout Document. Verified live against SPRINT-HULY-REST-LIVEQUERY-BRIDGE-017 (7 issues closed).
- **UT-153 — Document/Teamspace field fixes:** Adds required fields (`parent`, `rank`, counter fields) to `upsertDoc()` create TX and (`type`, `title`, `autoJoin`) to `resolveOrCreateTeamspace()`. Includes diagnostic/backfill scripts.

## Files Changed

| File | Change |
|------|--------|
| `tools/huly-os/daemon/operator.ts` | Phase 6: bidirectional sync (~60 lines) |
| `tools/huly-os/daemon/adapters/huly-adapter.ts` | Document + Teamspace field fixes |
| `tools/huly-os/package.json` | Add `sprint:close` script |
| `tools/huly-os/scripts/sprint-close.ts` | New — sprint closeout CLI |
| `tools/huly-os/scripts/doc-visibility-test.ts` | New — diagnostic script |
| `tools/huly-os/scripts/backfill-doc-fields.ts` | New — backfill missing fields |

## Test plan

- [x] `pnpm -C tools/huly-os run type-check` passes clean
- [x] `sprint:close` dry-run verified (7 related issues found)
- [x] `sprint:close` live run verified (7 issues → Done, closeout document published)
- [x] Playwright verification: UT-141 shows Done with all sub-issues in Done group
- [ ] Run `huly:operator:once` to verify Phase 6 auto-transitions (requires merged PRs with issue refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)