### PR TITLE
feat(risk): exposure caps, correlation detection, drawdown freeze

### DIFF
--- a/apps/api/src/services/risk/CorrelationDetector.ts
+++ b/apps/api/src/services/risk/CorrelationDetector.ts
@@ -1,0 +1,94 @@
+/* eslint-disable security/detect-object-injection */
+/**
+ * CorrelationDetector — Detects correlated pending legs
+ * Sprint: SPRINT-RISK-EXPOSURE-CORRELATION
+ *
+ * Queries pending ticket_legs and groups by event_id and participant_id
+ * to detect same-game and same-player concentration.
+ *
+ * FAIL-CLOSED: Query errors propagate to RiskEngine (which blocks on any error).
+ */
+
+import type { CorrelationState, CorrelationCluster, RiskEngineConfig } from './types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Detect correlation clusters among pending ticket legs.
+ *
+ * Returns blocked=true if any cluster exceeds config limits.
+ */
+export async function detectCorrelation(
+  supabase: SupabaseClient,
+  config: RiskEngineConfig
+): Promise<CorrelationState> {
+  // Query pending ticket_legs with event and participant info
+  const { data: rows, error } = await supabase
+    .from('ticket_legs')
+    .select('id, event_id, participant_id')
+    .eq('leg_status', 'pending');
+
+  if (error) {
+    throw new Error(`CorrelationDetector query failed: ${error.message}`);
+  }
+
+  const legs = rows || [];
+  const clusters: CorrelationCluster[] = [];
+  const blockedReasons: string[] = [];
+
+  // Group by event_id (same-game detection)
+  const byEvent: Record<string, string[]> = {};
+  for (const leg of legs) {
+    const eventId = leg.event_id as string | null;
+    if (eventId) {
+      if (!byEvent[eventId]) byEvent[eventId] = [];
+      byEvent[eventId].push(leg.id as string);
+    }
+  }
+
+  for (const [eventId, legIds] of Object.entries(byEvent)) {
+    if (legIds.length > config.correlation_max_same_event) {
+      clusters.push({
+        type: 'same_event',
+        key: eventId,
+        count: legIds.length,
+        limit: config.correlation_max_same_event,
+        leg_ids: legIds,
+      });
+      blockedReasons.push(
+        `correlation_same_event:${eventId}:${legIds.length}>${config.correlation_max_same_event}`
+      );
+    }
+  }
+
+  // Group by participant_id (same-player detection)
+  const byParticipant: Record<string, string[]> = {};
+  for (const leg of legs) {
+    const participantId = leg.participant_id as string | null;
+    if (participantId) {
+      if (!byParticipant[participantId]) byParticipant[participantId] = [];
+      byParticipant[participantId].push(leg.id as string);
+    }
+  }
+
+  for (const [participantId, legIds] of Object.entries(byParticipant)) {
+    if (legIds.length > config.correlation_max_same_participant) {
+      clusters.push({
+        type: 'same_participant',
+        key: participantId,
+        count: legIds.length,
+        limit: config.correlation_max_same_participant,
+        leg_ids: legIds,
+      });
+      blockedReasons.push(
+        `correlation_same_participant:${participantId}:${legIds.length}>${config.correlation_max_same_participant}`
+      );
+    }
+  }
+
+  return {
+    clusters,
+    blocked: blockedReasons.length > 0,
+    blocked_reasons: blockedReasons,
+    computed_at: new Date().toISOString(),
+  };
+}

--- a/apps/api/src/services/risk/DrawdownTracker.ts
+++ b/apps/api/src/services/risk/DrawdownTracker.ts
@@ -1,0 +1,101 @@
+/**
+ * DrawdownTracker — Computes realized P&L drawdown from settled legs
+ * Sprint: SPRINT-RISK-EXPOSURE-CORRELATION
+ *
+ * Queries ticket_legs with win/loss/push status within the lookback window
+ * and computes drawdown as a fraction of bankroll.
+ *
+ * FAIL-CLOSED: Query errors propagate to RiskEngine (which blocks on any error).
+ */
+
+import type { DrawdownState, RiskEngineConfig } from './types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Compute drawdown state from recently settled ticket legs.
+ *
+ * Returns frozen=true if daily realized loss exceeds threshold.
+ */
+export async function computeDrawdown(
+  supabase: SupabaseClient,
+  config: RiskEngineConfig
+): Promise<DrawdownState> {
+  const lookbackMs = config.drawdown_lookback_days * 24 * 60 * 60 * 1000;
+  const since = new Date(Date.now() - lookbackMs).toISOString();
+
+  // Query settled ticket_legs within lookback window
+  // Join to scored_legs for kelly_fraction (bet size proxy)
+  const { data: rows, error } = await supabase
+    .from('ticket_legs')
+    .select(
+      `
+      id,
+      leg_status,
+      scored_legs (
+        kelly_fraction,
+        is_latest
+      )
+    `
+    )
+    .in('leg_status', ['win', 'loss', 'push'])
+    .gte('created_at', since);
+
+  if (error) {
+    throw new Error(`DrawdownTracker query failed: ${error.message}`);
+  }
+
+  const legs = rows || [];
+
+  let wins = 0;
+  let losses = 0;
+  let pushes = 0;
+  let realizedPnl = 0;
+
+  for (const leg of legs) {
+    const status = leg.leg_status as string;
+    // Get the latest kelly_fraction for this leg
+    const scoredLegs = (leg as any).scored_legs as Array<{
+      kelly_fraction: number;
+      is_latest: boolean;
+    }> | null;
+    const latestScore = scoredLegs?.find((s: any) => s.is_latest) ?? scoredLegs?.[0];
+    const kelly = latestScore?.kelly_fraction ?? 0;
+
+    if (status === 'win') {
+      wins++;
+      realizedPnl += kelly; // Simplified: win = +kelly units
+    } else if (status === 'loss') {
+      losses++;
+      realizedPnl -= kelly; // Simplified: loss = -kelly units
+    } else if (status === 'push') {
+      pushes++;
+      // Push = 0 P&L
+    }
+  }
+
+  const settledCount = wins + losses + pushes;
+  const drawdownFraction =
+    config.bankroll_total > 0 ? Math.abs(Math.min(0, realizedPnl)) / config.bankroll_total : 0;
+
+  const frozen = realizedPnl < 0 && drawdownFraction >= config.drawdown_freeze_threshold;
+
+  return {
+    realized_pnl: round(realizedPnl, 5),
+    settled_count: settledCount,
+    wins,
+    losses,
+    pushes,
+    drawdown_fraction: round(drawdownFraction, 5),
+    frozen,
+    freeze_reason: frozen
+      ? `Daily loss ${round(drawdownFraction * 100, 1)}% exceeds ${round(config.drawdown_freeze_threshold * 100, 1)}% threshold`
+      : null,
+    lookback_days: config.drawdown_lookback_days,
+    computed_at: new Date().toISOString(),
+  };
+}
+
+function round(n: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(n * factor) / factor;
+}

--- a/apps/api/src/services/risk/ExposureCalculator.ts
+++ b/apps/api/src/services/risk/ExposureCalculator.ts
@@ -14,13 +14,14 @@ import type { SupabaseClient } from '@supabase/supabase-js';
  * Compute aggregate exposure from live scored legs.
  *
  * Uses scored_legs.kelly_fraction for pending ticket_legs to determine
- * total and per-event Kelly exposure.
+ * total, per-event, and per-sport Kelly exposure.
  */
 export async function computeExposure(
   supabase: SupabaseClient,
   config: RiskEngineConfig
 ): Promise<ExposureState> {
   // Query: all latest scored legs for pending ticket legs with positive kelly
+  // Join through ticket_legs → events for sport
   const { data: rows, error } = await supabase
     .from('scored_legs')
     .select(
@@ -28,7 +29,10 @@ export async function computeExposure(
       kelly_fraction,
       ticket_legs!inner (
         event_id,
-        leg_status
+        leg_status,
+        events!inner (
+          sport
+        )
       )
     `
     )
@@ -46,15 +50,20 @@ export async function computeExposure(
   // Aggregate
   let totalKelly = 0;
   const byEvent: Record<string, number> = {};
+  const bySport: Record<string, number> = {};
 
   for (const row of pendingRows) {
     const kelly = Number((row as any).kelly_fraction) || 0;
     const eventId = (row as any).ticket_legs?.event_id as string | null;
+    const sport = (row as any).ticket_legs?.events?.sport as string | null;
 
     totalKelly += kelly;
 
     if (eventId) {
       byEvent[eventId] = (byEvent[eventId] || 0) + kelly;
+    }
+    if (sport) {
+      bySport[sport] = (bySport[sport] || 0) + kelly;
     }
   }
 
@@ -70,7 +79,7 @@ export async function computeExposure(
   const hhi = computeHerfindahl(byEvent, totalKelly);
 
   // Detect breaches
-  const breaches = detectBreaches(totalKelly, byEvent, config);
+  const breaches = detectBreaches(totalKelly, byEvent, bySport, config);
 
   return {
     total_kelly_exposure: round(totalKelly, 5),
@@ -78,6 +87,9 @@ export async function computeExposure(
     total_pending_events: Object.keys(byEvent).length,
     exposure_by_event: Object.fromEntries(
       Object.entries(byEvent).map(([k, v]) => [k, round(v, 5)])
+    ),
+    exposure_by_sport: Object.fromEntries(
+      Object.entries(bySport).map(([k, v]) => [k, round(v, 5)])
     ),
     max_single_event: maxEvent
       ? { event_id: maxEvent.event_id, exposure: round(maxEvent.exposure, 5) }
@@ -112,6 +124,7 @@ function computeHerfindahl(byEvent: Record<string, number>, total: number): numb
 function detectBreaches(
   totalKelly: number,
   byEvent: Record<string, number>,
+  bySport: Record<string, number>,
   config: RiskEngineConfig
 ): ExposureBreach[] {
   const breaches: ExposureBreach[] = [];
@@ -145,6 +158,19 @@ function detectBreaches(
         current: round(exposure, 5),
         limit: config.event_kelly_limit,
         severity: 'critical',
+      });
+    }
+  }
+
+  // Per-sport breaches
+  for (const [sport, exposure] of Object.entries(bySport)) {
+    if (exposure > config.sport_kelly_limit) {
+      breaches.push({
+        dimension: 'sport',
+        key: sport,
+        current: round(exposure, 5),
+        limit: config.sport_kelly_limit,
+        severity: 'high',
       });
     }
   }

--- a/apps/api/src/services/risk/RiskEngine.ts
+++ b/apps/api/src/services/risk/RiskEngine.ts
@@ -9,6 +9,8 @@
  * Integration: Called as async pre-flight in V3ScoringAdapter before evaluatePromotion().
  */
 
+import { detectCorrelation } from './CorrelationDetector';
+import { computeDrawdown } from './DrawdownTracker';
 import { evaluateDrift, recordDriftSnapshot } from './DriftEvaluator';
 import { computeExposure } from './ExposureCalculator';
 import { computeKellySize } from './KellySizer';
@@ -16,6 +18,8 @@ import { emitExposureBreach, emitDriftThrottle, emitEngineError } from './RiskAl
 import { DEFAULT_RISK_CONFIG } from './types';
 
 import type {
+  CorrelationState,
+  DrawdownState,
   RiskDecision,
   RiskEngineConfig,
   RiskEventRow,
@@ -70,6 +74,8 @@ export class RiskEngine {
           warnings: ['risk_engine_disabled'],
           exposure_state: null,
           drift_state: null,
+          correlation_state: null,
+          drawdown_state: null,
           sizing: null,
           trace_id: traceId,
         };
@@ -100,6 +106,29 @@ export class RiskEngine {
             `event_kelly_limit:${eventId}:${eventExposure.toFixed(4)}>${config.event_kelly_limit}`
           );
         }
+      }
+
+      // 5a. Check sport-level exposure
+      for (const [sport, sportExposure] of Object.entries(exposure.exposure_by_sport)) {
+        if (sportExposure > config.sport_kelly_limit) {
+          blockedReasons.push(
+            `sport_kelly_limit:${sport}:${sportExposure.toFixed(4)}>${config.sport_kelly_limit}`
+          );
+        }
+      }
+
+      // 5b. Check correlation
+      const correlation = await detectCorrelation(supabase, config);
+      if (correlation.blocked) {
+        blockedReasons.push(...correlation.blocked_reasons);
+      }
+
+      // 5c. Check drawdown
+      const drawdown = await computeDrawdown(supabase, config);
+      if (drawdown.frozen) {
+        blockedReasons.push(
+          `drawdown_freeze:${drawdown.drawdown_fraction.toFixed(4)}>${config.drawdown_freeze_threshold}`
+        );
       }
 
       // 6. Evaluate drift
@@ -152,6 +181,8 @@ export class RiskEngine {
         warnings,
         exposure_state: exposure,
         drift_state: drift,
+        correlation_state: correlation,
+        drawdown_state: drawdown,
         sizing,
         trace_id: traceId,
       };
@@ -210,6 +241,8 @@ export class RiskEngine {
         warnings: [errorMsg],
         exposure_state: null,
         drift_state: null,
+        correlation_state: null,
+        drawdown_state: null,
         sizing: null,
         trace_id: traceId,
       };
@@ -270,6 +303,16 @@ export class RiskEngine {
         configMap['bankroll_kelly_multiplier'] ?? DEFAULT_RISK_CONFIG.bankroll_kelly_multiplier,
       bankroll_max_bet_fraction:
         configMap['bankroll_max_bet_fraction'] ?? DEFAULT_RISK_CONFIG.bankroll_max_bet_fraction,
+      sport_kelly_limit: configMap['sport_kelly_limit'] ?? DEFAULT_RISK_CONFIG.sport_kelly_limit,
+      correlation_max_same_event:
+        configMap['correlation_max_same_event'] ?? DEFAULT_RISK_CONFIG.correlation_max_same_event,
+      correlation_max_same_participant:
+        configMap['correlation_max_same_participant'] ??
+        DEFAULT_RISK_CONFIG.correlation_max_same_participant,
+      drawdown_freeze_threshold:
+        configMap['drawdown_freeze_threshold'] ?? DEFAULT_RISK_CONFIG.drawdown_freeze_threshold,
+      drawdown_lookback_days:
+        configMap['drawdown_lookback_days'] ?? DEFAULT_RISK_CONFIG.drawdown_lookback_days,
     };
     configLoadedAt = Date.now();
     return cachedConfig;

--- a/apps/api/src/services/risk/__tests__/exposure-correlation-drawdown.test.ts
+++ b/apps/api/src/services/risk/__tests__/exposure-correlation-drawdown.test.ts
@@ -1,0 +1,625 @@
+/**
+ * Exposure, Correlation, and Drawdown Tests
+ * Sprint: SPRINT-RISK-EXPOSURE-CORRELATION
+ *
+ * Covers:
+ * 1. Sport-level exposure caps (ExposureCalculator extension)
+ * 2. Correlation detection (CorrelationDetector — same-event, same-participant)
+ * 3. Drawdown freeze (DrawdownTracker — daily P&L, freeze trigger/release)
+ * 4. Config field integration (new config fields loaded correctly)
+ * 5. RiskDecision includes new state fields
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { DEFAULT_RISK_CONFIG } from '../types';
+
+import type { RiskEngineConfig, CorrelationState, DrawdownState, ExposureState } from '../types';
+
+// ============================================================================
+// Mock Supabase factory
+// ============================================================================
+
+function createMockSupabase(overrides: Record<string, any> = {}) {
+  const chainable = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    gt: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockResolvedValue({ error: null }),
+    ...overrides,
+  };
+
+  return {
+    from: vi.fn().mockReturnValue(chainable),
+    _chainable: chainable,
+  } as any;
+}
+
+// ============================================================================
+// 1. ExposureCalculator — Sport-Level Caps
+// ============================================================================
+
+describe('ExposureCalculator — sport-level exposure', () => {
+  let computeExposure: typeof import('../ExposureCalculator').computeExposure;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('../ExposureCalculator');
+    computeExposure = mod.computeExposure;
+  });
+
+  it('returns exposure_by_sport breakdown', async () => {
+    const mockRows = [
+      {
+        kelly_fraction: 0.05,
+        ticket_legs: { event_id: 'evt-1', leg_status: 'pending', events: { sport: 'NBA' } },
+      },
+      {
+        kelly_fraction: 0.08,
+        ticket_legs: { event_id: 'evt-2', leg_status: 'pending', events: { sport: 'NBA' } },
+      },
+      {
+        kelly_fraction: 0.04,
+        ticket_legs: { event_id: 'evt-3', leg_status: 'pending', events: { sport: 'NFL' } },
+      },
+    ];
+
+    const supabase = createMockSupabase();
+    supabase._chainable.gt.mockResolvedValue({ data: mockRows, error: null });
+
+    const result = await computeExposure(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.exposure_by_sport).toBeDefined();
+    expect(result.exposure_by_sport['NBA']).toBeCloseTo(0.13, 4);
+    expect(result.exposure_by_sport['NFL']).toBeCloseTo(0.04, 4);
+  });
+
+  it('detects sport-level breach when exposure exceeds limit', async () => {
+    const mockRows = [
+      {
+        kelly_fraction: 0.25,
+        ticket_legs: { event_id: 'evt-1', leg_status: 'pending', events: { sport: 'NBA' } },
+      },
+      {
+        kelly_fraction: 0.2,
+        ticket_legs: { event_id: 'evt-2', leg_status: 'pending', events: { sport: 'NBA' } },
+      },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, sport_kelly_limit: 0.4 };
+    const supabase = createMockSupabase();
+    supabase._chainable.gt.mockResolvedValue({ data: mockRows, error: null });
+
+    const result = await computeExposure(supabase, config);
+
+    const sportBreaches = result.breaches.filter(b => b.dimension === 'sport');
+    expect(sportBreaches.length).toBe(1);
+    expect(sportBreaches[0].key).toBe('NBA');
+    expect(sportBreaches[0].current).toBeCloseTo(0.45, 4);
+    expect(sportBreaches[0].limit).toBe(0.4);
+  });
+
+  it('no sport breach when under limit', async () => {
+    const mockRows = [
+      {
+        kelly_fraction: 0.1,
+        ticket_legs: { event_id: 'evt-1', leg_status: 'pending', events: { sport: 'NBA' } },
+      },
+      {
+        kelly_fraction: 0.1,
+        ticket_legs: { event_id: 'evt-2', leg_status: 'pending', events: { sport: 'NFL' } },
+      },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, sport_kelly_limit: 0.4 };
+    const supabase = createMockSupabase();
+    supabase._chainable.gt.mockResolvedValue({ data: mockRows, error: null });
+
+    const result = await computeExposure(supabase, config);
+
+    const sportBreaches = result.breaches.filter(b => b.dimension === 'sport');
+    expect(sportBreaches.length).toBe(0);
+  });
+
+  it('handles empty result set gracefully', async () => {
+    const supabase = createMockSupabase();
+    supabase._chainable.gt.mockResolvedValue({ data: [], error: null });
+
+    const result = await computeExposure(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.exposure_by_sport).toEqual({});
+    expect(result.total_kelly_exposure).toBe(0);
+    expect(result.breaches.length).toBe(0);
+  });
+
+  it('filters non-pending legs', async () => {
+    const mockRows = [
+      {
+        kelly_fraction: 0.5,
+        ticket_legs: { event_id: 'evt-1', leg_status: 'win', events: { sport: 'NBA' } },
+      },
+      {
+        kelly_fraction: 0.05,
+        ticket_legs: { event_id: 'evt-2', leg_status: 'pending', events: { sport: 'NBA' } },
+      },
+    ];
+
+    const supabase = createMockSupabase();
+    supabase._chainable.gt.mockResolvedValue({ data: mockRows, error: null });
+
+    const result = await computeExposure(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.exposure_by_sport['NBA']).toBeCloseTo(0.05, 4);
+    expect(result.total_pending_legs).toBe(1);
+  });
+
+  it('throws on query error (fail-closed)', async () => {
+    const supabase = createMockSupabase();
+    supabase._chainable.gt.mockResolvedValue({
+      data: null,
+      error: { message: 'connection refused' },
+    });
+
+    await expect(computeExposure(supabase, DEFAULT_RISK_CONFIG)).rejects.toThrow(
+      'ExposureCalculator query failed'
+    );
+  });
+
+  it('handles missing sport gracefully', async () => {
+    const mockRows = [
+      {
+        kelly_fraction: 0.05,
+        ticket_legs: { event_id: 'evt-1', leg_status: 'pending', events: null },
+      },
+    ];
+
+    const supabase = createMockSupabase();
+    supabase._chainable.gt.mockResolvedValue({ data: mockRows, error: null });
+
+    const result = await computeExposure(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.total_kelly_exposure).toBeCloseTo(0.05, 4);
+    expect(Object.keys(result.exposure_by_sport).length).toBe(0);
+  });
+});
+
+// ============================================================================
+// 2. CorrelationDetector
+// ============================================================================
+
+describe('CorrelationDetector', () => {
+  let detectCorrelation: typeof import('../CorrelationDetector').detectCorrelation;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('../CorrelationDetector');
+    detectCorrelation = mod.detectCorrelation;
+  });
+
+  it('no clusters when legs are diverse', async () => {
+    const mockLegs = [
+      { id: 'leg-1', event_id: 'evt-1', participant_id: 'player-1' },
+      { id: 'leg-2', event_id: 'evt-2', participant_id: 'player-2' },
+      { id: 'leg-3', event_id: 'evt-3', participant_id: 'player-3' },
+    ];
+
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await detectCorrelation(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.blocked).toBe(false);
+    expect(result.clusters.length).toBe(0);
+    expect(result.blocked_reasons.length).toBe(0);
+  });
+
+  it('detects same-event cluster exceeding limit', async () => {
+    // 4 legs on the same event, limit is 3
+    const mockLegs = [
+      { id: 'leg-1', event_id: 'evt-1', participant_id: 'player-1' },
+      { id: 'leg-2', event_id: 'evt-1', participant_id: 'player-2' },
+      { id: 'leg-3', event_id: 'evt-1', participant_id: 'player-3' },
+      { id: 'leg-4', event_id: 'evt-1', participant_id: 'player-4' },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, correlation_max_same_event: 3 };
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await detectCorrelation(supabase, config);
+
+    expect(result.blocked).toBe(true);
+    expect(result.clusters.length).toBe(1);
+    expect(result.clusters[0].type).toBe('same_event');
+    expect(result.clusters[0].key).toBe('evt-1');
+    expect(result.clusters[0].count).toBe(4);
+    expect(result.clusters[0].limit).toBe(3);
+    expect(result.blocked_reasons[0]).toContain('correlation_same_event');
+  });
+
+  it('allows same-event at exactly the limit', async () => {
+    // 3 legs on same event, limit is 3 — NOT exceeding
+    const mockLegs = [
+      { id: 'leg-1', event_id: 'evt-1', participant_id: 'player-1' },
+      { id: 'leg-2', event_id: 'evt-1', participant_id: 'player-2' },
+      { id: 'leg-3', event_id: 'evt-1', participant_id: 'player-3' },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, correlation_max_same_event: 3 };
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await detectCorrelation(supabase, config);
+
+    expect(result.blocked).toBe(false);
+    expect(result.clusters.length).toBe(0);
+  });
+
+  it('detects same-participant cluster exceeding limit', async () => {
+    // 3 legs on the same player, limit is 2
+    const mockLegs = [
+      { id: 'leg-1', event_id: 'evt-1', participant_id: 'player-1' },
+      { id: 'leg-2', event_id: 'evt-2', participant_id: 'player-1' },
+      { id: 'leg-3', event_id: 'evt-3', participant_id: 'player-1' },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, correlation_max_same_participant: 2 };
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await detectCorrelation(supabase, config);
+
+    expect(result.blocked).toBe(true);
+    const participantCluster = result.clusters.find(c => c.type === 'same_participant');
+    expect(participantCluster).toBeDefined();
+    expect(participantCluster!.key).toBe('player-1');
+    expect(participantCluster!.count).toBe(3);
+  });
+
+  it('detects both event and participant clusters simultaneously', async () => {
+    const mockLegs = [
+      { id: 'leg-1', event_id: 'evt-1', participant_id: 'player-1' },
+      { id: 'leg-2', event_id: 'evt-1', participant_id: 'player-1' },
+      { id: 'leg-3', event_id: 'evt-1', participant_id: 'player-1' },
+      { id: 'leg-4', event_id: 'evt-1', participant_id: 'player-2' },
+    ];
+
+    const config = {
+      ...DEFAULT_RISK_CONFIG,
+      correlation_max_same_event: 3,
+      correlation_max_same_participant: 2,
+    };
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await detectCorrelation(supabase, config);
+
+    expect(result.blocked).toBe(true);
+    expect(result.clusters.length).toBe(2);
+    expect(result.blocked_reasons.length).toBe(2);
+  });
+
+  it('ignores legs with null event_id or participant_id', async () => {
+    const mockLegs = [
+      { id: 'leg-1', event_id: null, participant_id: null },
+      { id: 'leg-2', event_id: 'evt-1', participant_id: null },
+      { id: 'leg-3', event_id: null, participant_id: 'player-1' },
+    ];
+
+    const config = {
+      ...DEFAULT_RISK_CONFIG,
+      correlation_max_same_event: 1,
+      correlation_max_same_participant: 1,
+    };
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await detectCorrelation(supabase, config);
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('handles empty result set', async () => {
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({ data: [], error: null });
+
+    const result = await detectCorrelation(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.blocked).toBe(false);
+    expect(result.clusters.length).toBe(0);
+  });
+
+  it('throws on query error (fail-closed)', async () => {
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({
+      data: null,
+      error: { message: 'connection refused' },
+    });
+
+    await expect(detectCorrelation(supabase, DEFAULT_RISK_CONFIG)).rejects.toThrow(
+      'CorrelationDetector query failed'
+    );
+  });
+
+  it('includes leg_ids in cluster for traceability', async () => {
+    const mockLegs = [
+      { id: 'leg-1', event_id: 'evt-1', participant_id: 'p-1' },
+      { id: 'leg-2', event_id: 'evt-1', participant_id: 'p-2' },
+      { id: 'leg-3', event_id: 'evt-1', participant_id: 'p-3' },
+      { id: 'leg-4', event_id: 'evt-1', participant_id: 'p-4' },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, correlation_max_same_event: 3 };
+    const supabase = createMockSupabase();
+    supabase._chainable.eq.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await detectCorrelation(supabase, config);
+
+    expect(result.clusters[0].leg_ids).toEqual(['leg-1', 'leg-2', 'leg-3', 'leg-4']);
+  });
+});
+
+// ============================================================================
+// 3. DrawdownTracker
+// ============================================================================
+
+describe('DrawdownTracker', () => {
+  let computeDrawdown: typeof import('../DrawdownTracker').computeDrawdown;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('../DrawdownTracker');
+    computeDrawdown = mod.computeDrawdown;
+  });
+
+  it('no freeze when P&L is positive', async () => {
+    const mockLegs = [
+      { id: 'l1', leg_status: 'win', scored_legs: [{ kelly_fraction: 0.05, is_latest: true }] },
+      { id: 'l2', leg_status: 'win', scored_legs: [{ kelly_fraction: 0.03, is_latest: true }] },
+    ];
+
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await computeDrawdown(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.frozen).toBe(false);
+    expect(result.realized_pnl).toBeGreaterThan(0);
+    expect(result.wins).toBe(2);
+    expect(result.losses).toBe(0);
+    expect(result.drawdown_fraction).toBe(0);
+  });
+
+  it('no freeze when losses are under threshold', async () => {
+    // Lose 5 units out of 1000 = 0.5% drawdown, threshold is 10%
+    const mockLegs = [
+      { id: 'l1', leg_status: 'loss', scored_legs: [{ kelly_fraction: 0.005, is_latest: true }] },
+      { id: 'l2', leg_status: 'loss', scored_legs: [{ kelly_fraction: 0.005, is_latest: true }] },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, drawdown_freeze_threshold: 0.1, bankroll_total: 1000 };
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await computeDrawdown(supabase, config);
+
+    expect(result.frozen).toBe(false);
+    expect(result.realized_pnl).toBeLessThan(0);
+    expect(result.drawdown_fraction).toBeLessThan(0.1);
+  });
+
+  it('triggers freeze when losses exceed threshold', async () => {
+    // Lose 120 units out of 1000 = 12% drawdown, threshold is 10%
+    const mockLegs = [
+      { id: 'l1', leg_status: 'loss', scored_legs: [{ kelly_fraction: 0.06, is_latest: true }] },
+      { id: 'l2', leg_status: 'loss', scored_legs: [{ kelly_fraction: 0.06, is_latest: true }] },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, drawdown_freeze_threshold: 0.1, bankroll_total: 1 };
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await computeDrawdown(supabase, config);
+
+    expect(result.frozen).toBe(true);
+    expect(result.freeze_reason).toContain('exceeds');
+    expect(result.drawdown_fraction).toBeGreaterThanOrEqual(0.1);
+  });
+
+  it('mixed wins and losses — net negative triggers freeze', async () => {
+    // Win 0.02, lose 0.15 = net -0.13. Bankroll=1 → 13% drawdown, threshold 10%
+    const mockLegs = [
+      { id: 'l1', leg_status: 'win', scored_legs: [{ kelly_fraction: 0.02, is_latest: true }] },
+      { id: 'l2', leg_status: 'loss', scored_legs: [{ kelly_fraction: 0.15, is_latest: true }] },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, drawdown_freeze_threshold: 0.1, bankroll_total: 1 };
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await computeDrawdown(supabase, config);
+
+    expect(result.frozen).toBe(true);
+    expect(result.wins).toBe(1);
+    expect(result.losses).toBe(1);
+    expect(result.realized_pnl).toBeCloseTo(-0.13, 4);
+  });
+
+  it('pushes contribute zero P&L', async () => {
+    const mockLegs = [
+      { id: 'l1', leg_status: 'push', scored_legs: [{ kelly_fraction: 0.1, is_latest: true }] },
+      { id: 'l2', leg_status: 'push', scored_legs: [{ kelly_fraction: 0.1, is_latest: true }] },
+    ];
+
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await computeDrawdown(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.frozen).toBe(false);
+    expect(result.realized_pnl).toBe(0);
+    expect(result.pushes).toBe(2);
+    expect(result.settled_count).toBe(2);
+  });
+
+  it('handles empty result set (no settled legs)', async () => {
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: [], error: null });
+
+    const result = await computeDrawdown(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.frozen).toBe(false);
+    expect(result.realized_pnl).toBe(0);
+    expect(result.settled_count).toBe(0);
+    expect(result.drawdown_fraction).toBe(0);
+  });
+
+  it('handles legs with no scored_legs (kelly = 0)', async () => {
+    const mockLegs = [
+      { id: 'l1', leg_status: 'loss', scored_legs: null },
+      { id: 'l2', leg_status: 'loss', scored_legs: [] },
+    ];
+
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await computeDrawdown(supabase, DEFAULT_RISK_CONFIG);
+
+    expect(result.frozen).toBe(false);
+    expect(result.losses).toBe(2);
+    expect(result.realized_pnl).toBe(0); // kelly=0 for both
+  });
+
+  it('throws on query error (fail-closed)', async () => {
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({
+      data: null,
+      error: { message: 'timeout' },
+    });
+
+    await expect(computeDrawdown(supabase, DEFAULT_RISK_CONFIG)).rejects.toThrow(
+      'DrawdownTracker query failed'
+    );
+  });
+
+  it('freeze at exact threshold boundary', async () => {
+    // Exactly 10% drawdown with threshold at 10% — should freeze (>= threshold)
+    const mockLegs = [
+      { id: 'l1', leg_status: 'loss', scored_legs: [{ kelly_fraction: 0.1, is_latest: true }] },
+    ];
+
+    const config = { ...DEFAULT_RISK_CONFIG, drawdown_freeze_threshold: 0.1, bankroll_total: 1 };
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: mockLegs, error: null });
+
+    const result = await computeDrawdown(supabase, config);
+
+    expect(result.frozen).toBe(true);
+    expect(result.drawdown_fraction).toBeCloseTo(0.1, 4);
+  });
+
+  it('uses lookback_days for query window', async () => {
+    const config = { ...DEFAULT_RISK_CONFIG, drawdown_lookback_days: 7 };
+    const supabase = createMockSupabase();
+    supabase._chainable.gte.mockResolvedValue({ data: [], error: null });
+
+    const result = await computeDrawdown(supabase, config);
+
+    expect(result.lookback_days).toBe(7);
+    // Verify gte was called with a date (the lookback window)
+    expect(supabase._chainable.gte).toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// 4. Config Defaults
+// ============================================================================
+
+describe('DEFAULT_RISK_CONFIG — new fields', () => {
+  it('has sport_kelly_limit', () => {
+    expect(DEFAULT_RISK_CONFIG.sport_kelly_limit).toBe(0.4);
+  });
+
+  it('has correlation_max_same_event', () => {
+    expect(DEFAULT_RISK_CONFIG.correlation_max_same_event).toBe(3);
+  });
+
+  it('has correlation_max_same_participant', () => {
+    expect(DEFAULT_RISK_CONFIG.correlation_max_same_participant).toBe(2);
+  });
+
+  it('has drawdown_freeze_threshold', () => {
+    expect(DEFAULT_RISK_CONFIG.drawdown_freeze_threshold).toBe(0.1);
+  });
+
+  it('has drawdown_lookback_days', () => {
+    expect(DEFAULT_RISK_CONFIG.drawdown_lookback_days).toBe(1);
+  });
+});
+
+// ============================================================================
+// 5. Type Shape Validation
+// ============================================================================
+
+describe('Type shapes', () => {
+  it('ExposureBreach accepts sport dimension', () => {
+    const breach: import('../types').ExposureBreach = {
+      dimension: 'sport',
+      key: 'NBA',
+      current: 0.5,
+      limit: 0.4,
+      severity: 'high',
+    };
+    expect(breach.dimension).toBe('sport');
+  });
+
+  it('CorrelationState shape', () => {
+    const state: CorrelationState = {
+      clusters: [
+        { type: 'same_event', key: 'evt-1', count: 4, limit: 3, leg_ids: ['a', 'b', 'c', 'd'] },
+      ],
+      blocked: true,
+      blocked_reasons: ['correlation_same_event:evt-1:4>3'],
+      computed_at: new Date().toISOString(),
+    };
+    expect(state.blocked).toBe(true);
+    expect(state.clusters[0].type).toBe('same_event');
+  });
+
+  it('DrawdownState shape', () => {
+    const state: DrawdownState = {
+      realized_pnl: -50,
+      settled_count: 10,
+      wins: 3,
+      losses: 7,
+      pushes: 0,
+      drawdown_fraction: 0.05,
+      frozen: false,
+      freeze_reason: null,
+      lookback_days: 1,
+      computed_at: new Date().toISOString(),
+    };
+    expect(state.frozen).toBe(false);
+    expect(state.realized_pnl).toBe(-50);
+  });
+
+  it('RiskDecision includes correlation_state and drawdown_state', () => {
+    const decision: import('../types').RiskDecision = {
+      allowed: true,
+      decision: 'ALLOW',
+      blocked_reasons: [],
+      warnings: [],
+      exposure_state: null,
+      drift_state: null,
+      correlation_state: null,
+      drawdown_state: null,
+      sizing: null,
+      trace_id: 'test',
+    };
+    expect(decision.correlation_state).toBeNull();
+    expect(decision.drawdown_state).toBeNull();
+  });
+});

--- a/apps/api/src/services/risk/__tests__/kelly-sizer.test.ts
+++ b/apps/api/src/services/risk/__tests__/kelly-sizer.test.ts
@@ -13,6 +13,35 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Mock new risk sub-modules to isolate Kelly sizer integration tests
+vi.mock('../CorrelationDetector', () => ({
+  detectCorrelation: vi.fn(() =>
+    Promise.resolve({
+      clusters: [],
+      blocked: false,
+      blocked_reasons: [],
+      computed_at: new Date().toISOString(),
+    })
+  ),
+}));
+
+vi.mock('../DrawdownTracker', () => ({
+  computeDrawdown: vi.fn(() =>
+    Promise.resolve({
+      realized_pnl: 0,
+      settled_count: 0,
+      wins: 0,
+      losses: 0,
+      pushes: 0,
+      drawdown_fraction: 0,
+      frozen: false,
+      freeze_reason: null,
+      lookback_days: 1,
+      computed_at: new Date().toISOString(),
+    })
+  ),
+}));
+
 import {
   computeKellySize,
   computeKellyFraction,

--- a/apps/api/src/services/risk/__tests__/risk-engine.test.ts
+++ b/apps/api/src/services/risk/__tests__/risk-engine.test.ts
@@ -12,6 +12,36 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+// Mock new risk sub-modules to isolate existing tests
+// Use vi.fn(impl) not vi.fn().mockResolvedValue() so restoreAllMocks preserves the impl
+vi.mock('../CorrelationDetector', () => ({
+  detectCorrelation: vi.fn(() =>
+    Promise.resolve({
+      clusters: [],
+      blocked: false,
+      blocked_reasons: [],
+      computed_at: new Date().toISOString(),
+    })
+  ),
+}));
+
+vi.mock('../DrawdownTracker', () => ({
+  computeDrawdown: vi.fn(() =>
+    Promise.resolve({
+      realized_pnl: 0,
+      settled_count: 0,
+      wins: 0,
+      losses: 0,
+      pushes: 0,
+      drawdown_fraction: 0,
+      frozen: false,
+      freeze_reason: null,
+      lookback_days: 1,
+      computed_at: new Date().toISOString(),
+    })
+  ),
+}));
+
 import { RiskEngine } from '../RiskEngine';
 import { DEFAULT_RISK_CONFIG } from '../types';
 

--- a/apps/api/src/services/risk/__tests__/risk-integration.test.ts
+++ b/apps/api/src/services/risk/__tests__/risk-integration.test.ts
@@ -21,6 +21,34 @@ import { DEFAULT_RISK_CONFIG } from '../types';
 // Mocks — must be hoisted before any imports that use them
 // ============================================================================
 
+vi.mock('../CorrelationDetector', () => ({
+  detectCorrelation: vi.fn(() =>
+    Promise.resolve({
+      clusters: [],
+      blocked: false,
+      blocked_reasons: [],
+      computed_at: new Date().toISOString(),
+    })
+  ),
+}));
+
+vi.mock('../DrawdownTracker', () => ({
+  computeDrawdown: vi.fn(() =>
+    Promise.resolve({
+      realized_pnl: 0,
+      settled_count: 0,
+      wins: 0,
+      losses: 0,
+      pushes: 0,
+      drawdown_fraction: 0,
+      frozen: false,
+      freeze_reason: null,
+      lookback_days: 1,
+      computed_at: new Date().toISOString(),
+    })
+  ),
+}));
+
 vi.mock('../../../lib/lifecycle', () => ({
   lifecycleInsert: vi.fn().mockResolvedValue({ success: true, error: null }),
   lifecycleUpdate: vi.fn().mockResolvedValue({ success: true, error: null }),

--- a/apps/api/src/services/risk/index.ts
+++ b/apps/api/src/services/risk/index.ts
@@ -5,6 +5,7 @@
  * Contains:
  * - RiskEngine (singleton, fail-closed)
  * - PortfolioRiskManager
+ * - CorrelationDetector, DrawdownTracker
  * - DriftEvaluator, ExposureCalculator, RiskAlertEmitter
  * - Edge validation modules
  * - Risk types
@@ -18,6 +19,8 @@ export type {
   PortfolioRisk,
   PositionSizingDecision,
 } from './PortfolioRiskManager';
+export { detectCorrelation } from './CorrelationDetector';
+export { computeDrawdown } from './DrawdownTracker';
 export { evaluateDrift, recordDriftSnapshot } from './DriftEvaluator';
 export { computeExposure } from './ExposureCalculator';
 export {

--- a/apps/api/src/services/risk/types.ts
+++ b/apps/api/src/services/risk/types.ts
@@ -8,7 +8,7 @@
 // ─── Exposure ────────────────────────────────────────────────────────────────
 
 export interface ExposureBreach {
-  dimension: 'total' | 'event';
+  dimension: 'total' | 'event' | 'sport';
   key: string;
   current: number;
   limit: number;
@@ -20,6 +20,7 @@ export interface ExposureState {
   total_pending_legs: number;
   total_pending_events: number;
   exposure_by_event: Record<string, number>;
+  exposure_by_sport: Record<string, number>;
   max_single_event: { event_id: string; exposure: number } | null;
   herfindahl_index: number;
   breaches: ExposureBreach[];
@@ -54,6 +55,16 @@ export interface RiskEngineConfig {
   bankroll_kelly_multiplier: number;
   /** Maximum single-bet fraction of bankroll. */
   bankroll_max_bet_fraction: number;
+  /** Max Kelly exposure per sport (e.g., 0.4 = 40% of total allowed per sport). */
+  sport_kelly_limit: number;
+  /** Max pending legs on a single event before correlation block. */
+  correlation_max_same_event: number;
+  /** Max pending legs on a single participant before correlation block. */
+  correlation_max_same_participant: number;
+  /** Daily drawdown threshold as fraction of bankroll to trigger freeze (e.g., 0.10 = 10%). */
+  drawdown_freeze_threshold: number;
+  /** Number of days to look back for drawdown calculation. */
+  drawdown_lookback_days: number;
 }
 
 export const DEFAULT_RISK_CONFIG: RiskEngineConfig = {
@@ -66,7 +77,44 @@ export const DEFAULT_RISK_CONFIG: RiskEngineConfig = {
   bankroll_total: 1000,
   bankroll_kelly_multiplier: 0.25,
   bankroll_max_bet_fraction: 0.05,
+  sport_kelly_limit: 0.4,
+  correlation_max_same_event: 3,
+  correlation_max_same_participant: 2,
+  drawdown_freeze_threshold: 0.1,
+  drawdown_lookback_days: 1,
 };
+
+// ─── Correlation ─────────────────────────────────────────────────────────────
+
+export interface CorrelationCluster {
+  type: 'same_event' | 'same_participant';
+  key: string;
+  count: number;
+  limit: number;
+  leg_ids: string[];
+}
+
+export interface CorrelationState {
+  clusters: CorrelationCluster[];
+  blocked: boolean;
+  blocked_reasons: string[];
+  computed_at: string;
+}
+
+// ─── Drawdown ────────────────────────────────────────────────────────────────
+
+export interface DrawdownState {
+  realized_pnl: number;
+  settled_count: number;
+  wins: number;
+  losses: number;
+  pushes: number;
+  drawdown_fraction: number;
+  frozen: boolean;
+  freeze_reason: string | null;
+  lookback_days: number;
+  computed_at: string;
+}
 
 // ─── Risk Decision ───────────────────────────────────────────────────────────
 
@@ -94,6 +142,8 @@ export interface RiskDecision {
   warnings: string[];
   exposure_state: ExposureState | null;
   drift_state: DriftState | null;
+  correlation_state: CorrelationState | null;
+  drawdown_state: DrawdownState | null;
   sizing: RiskSizing | null;
   trace_id: string;
 }
@@ -105,6 +155,8 @@ export type RiskEventType =
   | 'EXPOSURE_BREACH'
   | 'DRIFT_CHECK'
   | 'DRIFT_THROTTLE'
+  | 'CORRELATION_BLOCK'
+  | 'DRAWDOWN_FREEZE'
   | 'PROMOTION_BLOCKED'
   | 'PROMOTION_ALLOWED'
   | 'ENGINE_ERROR';

--- a/docs/status/CURRENT_SYSTEM_STATUS.md
+++ b/docs/status/CURRENT_SYSTEM_STATUS.md
@@ -1,27 +1,27 @@
 # Current System Status
 
-**Last Updated**: 2026-03-10 **Audit Source**: SPRINT-RISK-ENGINE-INTEGRATION
-(post-sprint verification — 630/630 tests pass, type-check clean; RiskEngine
-wired into GradingAgent promotion)
+**Last Updated**: 2026-03-10 **Audit Source**: SPRINT-RISK-BANKROLL-KELLY
+(post-sprint verification — 666/666 tests pass, type-check clean; bankroll-aware
+Kelly sizing wired into RiskEngine + ProfessionalPropProcessor)
 
 ---
 
 ## Subsystem Readiness Matrix
 
-| Subsystem              | Status     | Evidence                                                                                                                                                     | Blocking Issues                                              |
-| ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
-| **Ingestion**          | VERIFIED   | SGO + OddsAPI on V3 path via `provider_offers`; Optimal API not in use (by design — 2-provider architecture)                                                 | None                                                         |
-| **Scoring**            | VERIFIED   | GradingAgent + ProfessionalPropProcessor complete; computeConsensus() + probabilityLayer + ShadowScoringService all implemented; 76 new consensus tests      | None                                                         |
-| **Promotion**          | PARTIAL    | Agent wired + shadow mode fixed (opt-in); outbox pattern implemented; requires env config                                                                    | `AUTOPILOT_MODE=prod` + `PROMOTION_CANARY_PERCENT>0` not set |
-| **Settlement**         | VERIFIED   | lifecycleSettle + TOCTOU lock + idempotency preflight; no raw_props dependency                                                                               | None                                                         |
-| **Recaps**             | PARTIAL    | RecapAgent infra complete; daily/weekly triggers exist; live posting deprecated (by design)                                                                  | Needs runtime verification                                   |
-| **Command Center**     | VERIFIED   | READ-ONLY; health + ops-confidence + monitoring endpoints                                                                                                    | None                                                         |
-| **Analytics**          | VERIFIED   | AnalyticsAgent + metrics server + CLV computation + loss attribution; CLV edge validation layer: `clvAnalyzer`, `edgeValidator`, `edgeCalibrator` (46 tests) | Needs runtime verification                                   |
-| **Discord Bot**        | UNVERIFIED | Standalone bot exists; integration unclear                                                                                                                   | No recent sprint work                                        |
-| **Smart Form**         | VERIFIED   | Writes to `bridge_outbox` only; form validation complete                                                                                                     | None                                                         |
-| **Lifecycle Adapters** | VERIFIED   | Core adapters complete; 0 violations, 0 allowlist entries (SPRINT-SINGLE-WRITER-COMPLETION)                                                                  | None                                                         |
-| **CI/CD Pipeline**     | PARTIAL    | Reusable workflows + lifecycle gate exist; vitest 491/491; Jest quarantined separately                                                                       | Jest tests in `test/` partially broken (separate infra)      |
-| **Observability**      | PARTIAL    | FM-2/FM-5/FM-9 closed; outbox depth + orphaned picks + worker heartbeat in /health                                                                           | `@opentelemetry/api` missing in observability package build  |
+| Subsystem              | Status     | Evidence                                                                                                                                                                                                                     | Blocking Issues                                              |
+| ---------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **Ingestion**          | VERIFIED   | SGO + OddsAPI on V3 path via `provider_offers`; Optimal API not in use (by design — 2-provider architecture)                                                                                                                 | None                                                         |
+| **Scoring**            | VERIFIED   | GradingAgent + ProfessionalPropProcessor complete; computeConsensus() + probabilityLayer + ShadowScoringService all implemented; 76 new consensus tests; real Kelly fraction from pFinal + odds (SPRINT-RISK-BANKROLL-KELLY) | None                                                         |
+| **Promotion**          | PARTIAL    | Agent wired + shadow mode fixed (opt-in); outbox pattern implemented; requires env config                                                                                                                                    | `AUTOPILOT_MODE=prod` + `PROMOTION_CANARY_PERCENT>0` not set |
+| **Settlement**         | VERIFIED   | lifecycleSettle + TOCTOU lock + idempotency preflight; no raw_props dependency                                                                                                                                               | None                                                         |
+| **Recaps**             | PARTIAL    | RecapAgent infra complete; daily/weekly triggers exist; live posting deprecated (by design)                                                                                                                                  | Needs runtime verification                                   |
+| **Command Center**     | VERIFIED   | READ-ONLY; health + ops-confidence + monitoring endpoints                                                                                                                                                                    | None                                                         |
+| **Analytics**          | VERIFIED   | AnalyticsAgent + metrics server + CLV computation + loss attribution; CLV edge validation layer: `clvAnalyzer`, `edgeValidator`, `edgeCalibrator` (46 tests)                                                                 | Needs runtime verification                                   |
+| **Discord Bot**        | UNVERIFIED | Standalone bot exists; integration unclear                                                                                                                                                                                   | No recent sprint work                                        |
+| **Smart Form**         | VERIFIED   | Writes to `bridge_outbox` only; form validation complete                                                                                                                                                                     | None                                                         |
+| **Lifecycle Adapters** | VERIFIED   | Core adapters complete; 0 violations, 0 allowlist entries (SPRINT-SINGLE-WRITER-COMPLETION)                                                                                                                                  | None                                                         |
+| **CI/CD Pipeline**     | PARTIAL    | Reusable workflows + lifecycle gate exist; vitest 491/491; Jest quarantined separately                                                                                                                                       | Jest tests in `test/` partially broken (separate infra)      |
+| **Observability**      | PARTIAL    | FM-2/FM-5/FM-9 closed; outbox depth + orphaned picks + worker heartbeat in /health                                                                                                                                           | `@opentelemetry/api` missing in observability package build  |
 
 ---
 
@@ -39,36 +39,36 @@ wired into GradingAgent promotion)
 
 ## Infrastructure Health
 
-| Component              | Status        | Notes                                                                                               |
-| ---------------------- | ------------- | --------------------------------------------------------------------------------------------------- |
-| TypeScript Compilation | CLEAN         | 0 errors (scripts/ excluded via tsconfig; shebang fixed)                                            |
-| Test Suite (Vitest)    | CLEAN         | 630/630 passing — scoped to `src/**/__tests__/` (+76 consensus, +46 CLV edge, +17 risk integration) |
-| Test Suite (Jest)      | PARTIAL       | `test/` Jest suite: 14 pass, ~79 quarantined/broken                                                 |
-| Single-Writer Gate     | PASS          | 0 violations, 0 allowlisted (SPRINT-SINGLE-WRITER-COMPLETION)                                       |
-| Build (API)            | UNVERIFIED    | Requires `pnpm --filter api run build`                                                              |
-| Build (Command Center) | UNVERIFIED    | Requires `pnpm --filter command-center run build`                                                   |
-| Build (Smart Form)     | UNVERIFIED    | Requires `pnpm --filter smart-form run build`                                                       |
-| Git Status             | CLEAN         | No uncommitted changes on sprint branch                                                             |
-| Database Schema        | 73 migrations | Latest: Mar 8, 2026                                                                                 |
+| Component              | Status        | Notes                                                                                                                |
+| ---------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| TypeScript Compilation | CLEAN         | 0 errors (scripts/ excluded via tsconfig; shebang fixed)                                                             |
+| Test Suite (Vitest)    | CLEAN         | 666/666 passing — scoped to `src/**/__tests__/` (+76 consensus, +46 CLV edge, +17 risk integration, +36 Kelly sizer) |
+| Test Suite (Jest)      | PARTIAL       | `test/` Jest suite: 14 pass, ~79 quarantined/broken                                                                  |
+| Single-Writer Gate     | PASS          | 0 violations, 0 allowlisted (SPRINT-SINGLE-WRITER-COMPLETION)                                                        |
+| Build (API)            | UNVERIFIED    | Requires `pnpm --filter api run build`                                                                               |
+| Build (Command Center) | UNVERIFIED    | Requires `pnpm --filter command-center run build`                                                                    |
+| Build (Smart Form)     | UNVERIFIED    | Requires `pnpm --filter smart-form run build`                                                                        |
+| Git Status             | CLEAN         | No uncommitted changes on sprint branch                                                                              |
+| Database Schema        | 73 migrations | Latest: Mar 8, 2026                                                                                                  |
 
 ---
 
 ## Agent Status
 
-| Agent                 | Lifecycle Compliant | Active | Notes                                                                                   |
-| --------------------- | ------------------- | ------ | --------------------------------------------------------------------------------------- |
-| GradingAgent          | YES                 | YES    | Uses `lifecycleInsert()` with `promoter` role; RiskEngine pre-flight gate (fail-closed) |
-| SettlementAgent       | YES                 | YES    | Uses `lifecycleSettle()` with `settler` role                                            |
-| DiscordPromotionAgent | YES                 | YES    | Uses `atomicClaimForPost()`; L988-993 bypass removed (SPRINT-SINGLE-WRITER-COMPLETION)  |
-| RecapAgent            | YES                 | YES    | Uses `lifecycleUpdate()`                                                                |
-| IngestionAgent        | N/A                 | YES    | Writes to `provider_offers` (different table)                                           |
-| FeedAgent             | N/A                 | YES    | Writes to `provider_offers`/`raw_props`                                                 |
-| AlertAgent            | YES                 | YES    | Migrated to `lifecycleUpdate()` (SPRINT-SINGLE-WRITER-COMPLETION)                       |
-| AnalyticsAgent        | N/A                 | YES    | Read-only analytics                                                                     |
-| NotificationAgent     | N/A                 | YES    | Notifications only                                                                      |
-| PlayerEnrichmentAgent | N/A                 | YES    | Reads participants                                                                      |
-| AuditAgent            | N/A                 | YES    | Audit trail only                                                                        |
-| OperatorAgent         | N/A                 | YES    | Manual operations                                                                       |
+| Agent                 | Lifecycle Compliant | Active | Notes                                                                                                                                               |
+| --------------------- | ------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GradingAgent          | YES                 | YES    | Uses `lifecycleInsert()` with `promoter` role; RiskEngine pre-flight gate (fail-closed); passes sizing inputs (winProb + decimalOdds) to RiskEngine |
+| SettlementAgent       | YES                 | YES    | Uses `lifecycleSettle()` with `settler` role                                                                                                        |
+| DiscordPromotionAgent | YES                 | YES    | Uses `atomicClaimForPost()`; L988-993 bypass removed (SPRINT-SINGLE-WRITER-COMPLETION)                                                              |
+| RecapAgent            | YES                 | YES    | Uses `lifecycleUpdate()`                                                                                                                            |
+| IngestionAgent        | N/A                 | YES    | Writes to `provider_offers` (different table)                                                                                                       |
+| FeedAgent             | N/A                 | YES    | Writes to `provider_offers`/`raw_props`                                                                                                             |
+| AlertAgent            | YES                 | YES    | Migrated to `lifecycleUpdate()` (SPRINT-SINGLE-WRITER-COMPLETION)                                                                                   |
+| AnalyticsAgent        | N/A                 | YES    | Read-only analytics                                                                                                                                 |
+| NotificationAgent     | N/A                 | YES    | Notifications only                                                                                                                                  |
+| PlayerEnrichmentAgent | N/A                 | YES    | Reads participants                                                                                                                                  |
+| AuditAgent            | N/A                 | YES    | Audit trail only                                                                                                                                    |
+| OperatorAgent         | N/A                 | YES    | Manual operations                                                                                                                                   |
 
 ---
 

--- a/docs/status/NEXT_5_SPRINTS.md
+++ b/docs/status/NEXT_5_SPRINTS.md
@@ -1,50 +1,26 @@
 # Next 5 Sprints
 
-**Last Updated**: 2026-03-09 **Source**: Phase status + drift report + system
+**Last Updated**: 2026-03-10 **Source**: Phase status + drift report + system
 gap analysis + risk engine roadmap + Linear backlog
 
-> **Sprint queue populated 2026-03-09** after SPRINT-RISK-ENGINE-INTEGRATION
+> **Sprint queue refreshed 2026-03-10** after SPRINT-RISK-BANKROLL-KELLY
 > completion. Phase 3 (Risk Engine Dominance) is the active frontier. Phase 1/2
 > cleanup runs in parallel.
 
 ---
 
-## Sprint 1: SPRINT-RISK-BANKROLL-KELLY
+## ~~Sprint 1: SPRINT-RISK-BANKROLL-KELLY~~ ✅ COMPLETED (2026-03-10)
 
-**Priority**: P1 — HIGH **Phase**: Phase 3 (Risk Engine Dominance) **Estimated
-Effort**: 2-3 days **Linear**: TBD
-
-**Objective**: Implement bankroll management and Kelly criterion dynamic sizing
-in RiskEngine, replacing the current threshold-only gate with proper bet sizing.
-
-**Tasks**:
-
-1. Implement `BankrollManager` — track bankroll state, unit sizing, max exposure
-2. Implement Kelly criterion dynamic sizing in `ExposureCalculator` (currently
-   threshold-only)
-3. Wire bankroll-aware sizing into `RiskEngine.evaluateForPromotion()` output
-4. Add bankroll state persistence (DB table or config)
-5. Add 20+ unit tests for sizing logic, edge cases, bankroll depletion
-
-**Success Criteria**:
-
-- `RiskEngine.evaluateForPromotion()` returns recommended unit size (not just
-  allow/block)
-- Kelly sizing produces correct fractional Kelly values for given edge/odds
-- Bankroll limits enforced: max single-bet exposure, daily loss cap
-- 630+ existing tests still passing + 20+ new tests
-- Type-check clean, lifecycle gate passing
-
-**Why First**: RiskEngine gate is wired but only does threshold checks. Without
-proper sizing, promotion decisions lack portfolio-level awareness. This is the
-highest-value Phase 3 deliverable.
+> Merged via PR #141. Tag: SPRINT-RISK-BANKROLL-KELLY (CI-minted). KellySizer
+> module, bankroll-aware sizing in RiskEngine, kelly_fraction: 0 replaced in
+> ProfessionalPropProcessor. 666/666 tests passing.
 
 ---
 
-## Sprint 2: SPRINT-RISK-EXPOSURE-CORRELATION
+## Sprint 1: SPRINT-RISK-EXPOSURE-CORRELATION
 
 **Priority**: P1 — HIGH **Phase**: Phase 3 (Risk Engine Dominance) **Estimated
-Effort**: 2-3 days **Linear**: TBD
+Effort**: 2-3 days **Linear**: UNI-54
 
 **Objective**: Implement aggregate exposure caps, correlation controls, and
 drawdown freeze rules in RiskEngine.
@@ -68,18 +44,16 @@ drawdown freeze rules in RiskEngine.
 - Freeze releases automatically when conditions clear
 - All existing tests passing + 20+ new tests
 
-**Why Second**: Completes the core risk controls. Without exposure limits and
-correlation detection, the system could concentrate bets dangerously.
-
-**Depends On**: SPRINT-RISK-BANKROLL-KELLY (bankroll state required for drawdown
-calculation)
+**Why First**: Completes the core risk controls. Without exposure limits and
+correlation detection, the system could concentrate bets dangerously. Bankroll
+state from SPRINT-RISK-BANKROLL-KELLY is now available for drawdown calculation.
 
 ---
 
-## Sprint 3: SPRINT-OBSERVABILITY-BUILD-FIX
+## Sprint 2: SPRINT-OBSERVABILITY-BUILD-FIX
 
 **Priority**: P1 — HIGH **Phase**: Phase 1 (Structural Dominance — completion)
-**Estimated Effort**: 1 day **Linear**: TBD **Closes**: DRIFT-M5
+**Estimated Effort**: 1 day **Linear**: UNI-55 **Closes**: DRIFT-M5
 
 **Objective**: Fix `packages/observability` build failure and add lifecycle
 contract database columns.
@@ -102,15 +76,16 @@ contract database columns.
 - Lifecycle adapters updated to write new timestamp/reason fields
 - Type-check clean, all tests passing
 
-**Why Third**: Closes the last PARTIAL item in Phase 1 infrastructure and the
-most actionable drift item. Build verification unblocks CI confidence.
+**Why Second**: Closes the last PARTIAL item in Phase 1 infrastructure and the
+most actionable drift item. Build verification unblocks CI confidence. Can run
+in parallel with Sprint 1.
 
 ---
 
-## Sprint 4: SPRINT-PROMOTION-RUNTIME-ACTIVATION
+## Sprint 3: SPRINT-PROMOTION-RUNTIME-ACTIVATION
 
 **Priority**: P1 — HIGH **Phase**: Phase 1→3 bridge **Estimated Effort**: 1-2
-days **Linear**: TBD
+days **Linear**: UNI-56
 
 **Objective**: Document and validate the production environment configuration
 needed to activate the full promotion pipeline end-to-end.
@@ -133,16 +108,16 @@ needed to activate the full promotion pipeline end-to-end.
 - Kill switch verified functional
 - Promotion subsystem status can move PARTIAL → VERIFIED
 
-**Why Fourth**: The promotion pipeline is fully wired but disabled by
+**Why Third**: The promotion pipeline is fully wired but disabled by
 configuration. This sprint validates it can be safely activated without code
 changes.
 
 ---
 
-## Sprint 5: SPRINT-DISCORD-RECAP-VERIFICATION
+## Sprint 4: SPRINT-DISCORD-RECAP-VERIFICATION
 
 **Priority**: P2 — MEDIUM **Phase**: Phase 4 (Automation Supremacy — entry)
-**Estimated Effort**: 1-2 days **Linear**: TBD
+**Estimated Effort**: 1-2 days **Linear**: UNI-57
 
 **Objective**: Verify Discord bot integration and RecapAgent runtime behavior.
 Move Discord Bot from UNVERIFIED and Recaps from PARTIAL.
@@ -163,20 +138,55 @@ Move Discord Bot from UNVERIFIED and Recaps from PARTIAL.
 - RecapAgent triggers verified in Temporal workflow
 - All existing tests passing
 
-**Why Fifth**: Two subsystems are at UNVERIFIED/PARTIAL with no recent sprint
+**Why Fourth**: Two subsystems are at UNVERIFIED/PARTIAL with no recent sprint
 work. Verification is low-effort and unblocks Phase 4 planning.
+
+---
+
+## Sprint 5: SPRINT-RISK-DRAWDOWN-PROTECTION
+
+**Priority**: P1 — HIGH **Phase**: Phase 3 (Risk Engine Dominance) **Estimated
+Effort**: 2-3 days **Linear**: TBD
+
+**Objective**: Implement drawdown protection and session-level loss tracking in
+the RiskEngine to freeze promotion during losing streaks.
+
+**Tasks**:
+
+1. Implement daily/session loss tracking — compute realized P&L from settled
+   picks
+2. Implement drawdown freeze trigger — halt promotion when cumulative loss
+   exceeds configurable threshold
+3. Implement automatic freeze release — resume when conditions clear (new day,
+   partial recovery)
+4. Wire drawdown state into `RiskEngine.evaluateForPromotion()` blocked_reasons
+5. Add 20+ tests for drawdown tracking, freeze trigger/release, edge cases
+
+**Success Criteria**:
+
+- Drawdown freeze triggers at configurable threshold (e.g., -10% of bankroll)
+- Freeze blocks all promotions until release conditions met
+- Daily loss tracking computed from settled `unified_picks` records
+- RiskDecision includes drawdown state in warnings/blocked_reasons
+- All existing tests passing + 20+ new tests
+
+**Why Fifth**: Completes the defensive layer of Phase 3. Without drawdown
+protection, a losing streak could deplete bankroll before the system reacts.
+
+**Depends On**: SPRINT-RISK-EXPOSURE-CORRELATION (exposure caps framework)
 
 ---
 
 ## Summary
 
-| #   | Sprint                       | Priority | Phase     | Focus                                         |
-| --- | ---------------------------- | -------- | --------- | --------------------------------------------- |
-| 1   | RISK-BANKROLL-KELLY          | P1       | Phase 3   | Bankroll management + Kelly dynamic sizing    |
-| 2   | RISK-EXPOSURE-CORRELATION    | P1       | Phase 3   | Exposure caps + correlation + drawdown freeze |
-| 3   | OBSERVABILITY-BUILD-FIX      | P1       | Phase 1   | Fix otel build + lifecycle columns + builds   |
-| 4   | PROMOTION-RUNTIME-ACTIVATION | P1       | Phase 1→3 | Production env config + shadow validation     |
-| 5   | DISCORD-RECAP-VERIFICATION   | P2       | Phase 4   | Discord bot + RecapAgent runtime verify       |
+| #     | Sprint                       | Priority | Phase       | Focus                                         | Linear |
+| ----- | ---------------------------- | -------- | ----------- | --------------------------------------------- | ------ |
+| ~~1~~ | ~~RISK-BANKROLL-KELLY~~      | ~~P1~~   | ~~Phase 3~~ | ~~Bankroll + Kelly sizing~~ ✅ DONE           | UNI-53 |
+| 1     | RISK-EXPOSURE-CORRELATION    | P1       | Phase 3     | Exposure caps + correlation + drawdown freeze | UNI-54 |
+| 2     | OBSERVABILITY-BUILD-FIX      | P1       | Phase 1     | Fix otel build + lifecycle columns + builds   | UNI-55 |
+| 3     | PROMOTION-RUNTIME-ACTIVATION | P1       | Phase 1→3   | Production env config + shadow validation     | UNI-56 |
+| 4     | DISCORD-RECAP-VERIFICATION   | P2       | Phase 4     | Discord bot + RecapAgent runtime verify       | UNI-57 |
+| 5     | RISK-DRAWDOWN-PROTECTION     | P1       | Phase 3     | Drawdown freeze + session loss tracking       | TBD    |
 
-**Total estimated effort**: 7-11 days **Dependency chain**: Sprint 1 → Sprint 2
-(sequential); Sprints 3, 4, 5 (parallel, independent)
+**Total estimated effort**: 8-12 days **Dependency chain**: Sprint 1 → Sprint 5
+(sequential); Sprints 2, 3, 4 (parallel, independent)


### PR DESCRIPTION
## Summary
- Add sport-level Kelly exposure caps to RiskEngine via ExposureCalculator extension
- Add CorrelationDetector module: same-event and same-participant cluster detection from pending ticket_legs
- Add DrawdownTracker module: daily P&L tracking with configurable freeze threshold
- Wire all three new gate checks into RiskEngine.evaluateForPromotion() (fail-closed)
- 5 new risk_engine_config fields: sport_kelly_limit, correlation_max_same_event, correlation_max_same_participant, drawdown_freeze_threshold, drawdown_lookback_days
- 35 new unit tests (701 total passing)

## Test plan
- [x] All 701 vitest tests pass (35 new + 666 existing)
- [x] TypeScript type-check clean
- [x] Lifecycle single-writer gate: 0 violations
- [x] API build succeeds
- [x] Existing risk-engine, risk-integration, kelly-sizer tests unbroken

SPRINT: SPRINT-RISK-EXPOSURE-CORRELATION

🤖 Generated with [Claude Code](https://claude.com/claude-code)