### PR TITLE
fix(docker): remove stale shared-types build steps from command-center and dashboard

### DIFF
--- a/apps/command-center/Dockerfile
+++ b/apps/command-center/Dockerfile
@@ -39,10 +39,6 @@ COPY apps/command-center ./apps/command-center
 # This runs AFTER copying source to create correct symlinks
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
-# SPRINT-RUNTIME-TRUTH-008: Build shared-types before app (monorepo dependency)
-WORKDIR /app/packages/shared-types
-RUN pnpm run build
-
 WORKDIR /app/apps/command-center
 
 # SPRINT-BUILD-TIME-ISOLATION-111: Accept build-time args for NEXT_PUBLIC_* vars

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -40,10 +40,6 @@ COPY apps/dashboard ./apps/dashboard
 # This runs AFTER copying source to create correct symlinks
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
-# SPRINT-RUNTIME-TRUTH-008: Build shared-types before app (monorepo dependency)
-WORKDIR /app/packages/shared-types
-RUN pnpm run build
-
 WORKDIR /app/apps/dashboard
 
 # Build Next.js application in production mode

--- a/docs/status/CURRENT_SYSTEM_STATUS.md
+++ b/docs/status/CURRENT_SYSTEM_STATUS.md
@@ -1,12 +1,13 @@
 # Current System Status
 
-**Last Updated**: 2026-03-14 (SPRINT-SMARTFORM-DOCKER-BUILD-TRUTH-FIX) **Audit
-Sources**: SPRINT-SMARTFORM-DOCKER-BUILD-TRUTH-FIX (Smart Form Docker build
-restored — stale shared-types step removed); SPRINT-LAYER1-PHASE5-E2E-CLOSURE
-(R3 shadow guardrails + R4 fault suite wired into CI; E2E lifecycle traversal
-proven; Phase 5 COMPLETE; Layer 1 COMPLETE);
-SPRINT-DISCORD-WORKER-HEALTH-RESTORE (bcbc20f7); SPRINT-VERIFICATION-GIT-COMMIT
-(a6f69276)
+**Last Updated**: 2026-03-14 (SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP) **Audit
+Sources**: SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP (command-center + dashboard
+Docker builds restored — stale shared-types steps removed from all 3 frontend
+Dockerfiles); SPRINT-SMARTFORM-DOCKER-BUILD-TRUTH-FIX (Smart Form Docker build
+restored); SPRINT-LAYER1-PHASE5-E2E-CLOSURE (R3 shadow guardrails + R4 fault
+suite wired into CI; E2E lifecycle traversal proven; Phase 5 COMPLETE; Layer 1
+COMPLETE); SPRINT-DISCORD-WORKER-HEALTH-RESTORE (bcbc20f7);
+SPRINT-VERIFICATION-GIT-COMMIT (a6f69276)
 
 ---
 
@@ -48,17 +49,19 @@ SPRINT-DISCORD-WORKER-HEALTH-RESTORE (bcbc20f7); SPRINT-VERIFICATION-GIT-COMMIT
 
 ## Infrastructure Health
 
-| Component              | Status        | Notes                                                                                                                                        |
-| ---------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| TypeScript Compilation | CLEAN         | 0 errors (scripts/ excluded via tsconfig; shebang fixed)                                                                                     |
-| Test Suite (Vitest)    | CLEAN         | 843/843 passing — scoped to `src/**/__tests__/` (+101 Discord/Recap verification tests SPRINT-DISCORD-RECAP-VERIFICATION)                    |
-| Test Suite (Jest)      | PARTIAL       | `test/` Jest suite: 14 pass, ~79 quarantined/broken                                                                                          |
-| Single-Writer Gate     | PASS          | 0 violations, 0 allowlisted (SPRINT-SINGLE-WRITER-COMPLETION)                                                                                |
-| Build (API)            | PASS          | `pnpm --filter unit-talk-platform run build` exits 0 (SPRINT-OBSERVABILITY-BUILD-FIX)                                                        |
-| Build (Command Center) | PASS          | `pnpm --filter unit-talk-command-center run build` exits 0; dynamic server warnings during SSG are expected (SPRINT-OBSERVABILITY-BUILD-FIX) |
-| Build (Smart Form)     | PASS          | Docker `development` target build succeeds; stale `packages/shared-types` build step removed (SPRINT-SMARTFORM-DOCKER-BUILD-TRUTH-FIX)       |
-| Git Status             | CLEAN         | No uncommitted changes on sprint branch                                                                                                      |
-| Database Schema        | 73 migrations | Latest: Mar 8, 2026                                                                                                                          |
+| Component              | Status        | Notes                                                                                                                                                                   |
+| ---------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TypeScript Compilation | CLEAN         | 0 errors (scripts/ excluded via tsconfig; shebang fixed)                                                                                                                |
+| Test Suite (Vitest)    | CLEAN         | 843/843 passing — scoped to `src/**/__tests__/` (+101 Discord/Recap verification tests SPRINT-DISCORD-RECAP-VERIFICATION)                                               |
+| Test Suite (Jest)      | PARTIAL       | `test/` Jest suite: 14 pass, ~79 quarantined/broken                                                                                                                     |
+| Single-Writer Gate     | PASS          | 0 violations, 0 allowlisted (SPRINT-SINGLE-WRITER-COMPLETION)                                                                                                           |
+| Build (API)            | PASS          | `pnpm --filter unit-talk-platform run build` exits 0 (SPRINT-OBSERVABILITY-BUILD-FIX)                                                                                   |
+| Build (Command Center) | PASS          | `pnpm --filter unit-talk-command-center run build` exits 0; dynamic server warnings during SSG are expected (SPRINT-OBSERVABILITY-BUILD-FIX)                            |
+| Build (Smart Form)     | PASS          | Docker `development` target build succeeds; stale `packages/shared-types` build step removed (SPRINT-SMARTFORM-DOCKER-BUILD-TRUTH-FIX)                                  |
+| Build (Command Center) | PASS          | Docker `development` target build succeeds; stale `packages/shared-types` build step removed (SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP)                                   |
+| Build (Dashboard)      | PASS          | Docker `development` target build succeeds; stale `packages/shared-types` build step removed; no `@unit-talk/*` workspace deps (SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP) |
+| Git Status             | CLEAN         | No uncommitted changes on sprint branch                                                                                                                                 |
+| Database Schema        | 73 migrations | Latest: Mar 8, 2026                                                                                                                                                     |
 
 ---
 

--- a/governance/closeouts/SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP.md
+++ b/governance/closeouts/SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP.md
@@ -1,0 +1,24 @@
+# Sprint Closeout — SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP
+
+**Sprint**: SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP **Date**: 2026-03-14
+**Status**: COMPLETE **Merged to**: main
+
+## Summary
+
+Audited all app Dockerfiles for stale `packages/shared-types` build steps.
+Patched `apps/command-center/Dockerfile` and `apps/dashboard/Dockerfile`. All 3
+frontend Docker development-stage builds now pass.
+
+## Impact
+
+- `Build (Command Center)`: BROKEN → PASS
+- `Build (Dashboard)`: BROKEN → PASS
+
+## Proof
+
+`out/sprints/SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP/2026-03-14/`
+
+- DOCKERFILE_INVENTORY.md
+- ROOT_CAUSE_AND_FIX_REPORT.md
+- BUILD_STARTUP_VERIFICATION.md
+- HANDOFF_SUMMARY.md


### PR DESCRIPTION
## Summary

- Removed stale `packages/shared-types` build steps from `apps/command-center/Dockerfile` and `apps/dashboard/Dockerfile` `development` stages
- Same root cause as PR #164 (smart-form): `SPRINT-RUNTIME-TRUTH-008` applied a template build step assuming `packages/shared-types` was a buildable pnpm workspace package — it has no `package.json`
- All 3 frontend apps (`smart-form`, `command-center`, `dashboard`) now have clean Docker `development` builds

## Root Cause

`SPRINT-RUNTIME-TRUTH-008` cloned identical stale lines into all 3 frontend Dockerfiles:
```dockerfile
# SPRINT-RUNTIME-TRUTH-008: Build shared-types before app (monorepo dependency)
WORKDIR /app/packages/shared-types
RUN pnpm run build
```
`packages/shared-types/` has no `package.json` → `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND`

## Dependency Truth

| App | Actual workspace dep | Needs explicit prebuild? |
|-----|---------------------|--------------------------|
| command-center | `@unit-talk/contracts: workspace:*` | NO — `contracts/dist/` in Docker context via `.dockerignore !packages/*/dist` |
| dashboard | No `@unit-talk/*` deps | NO |

## Test plan

- [x] `docker build --target development -f apps/command-center/Dockerfile` → PASS (9/9 stages, ~82s)
- [x] `docker build --target development -f apps/dashboard/Dockerfile` → PASS (9/9 stages, ~72s)
- [x] No remaining `packages/shared-types` references in startup-critical Dockerfiles
- [x] Status docs updated

## Sprint

`SPRINT-DOCKER-SHARED-TYPES-TRUTH-SWEEP` — Layer 2 / Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)