### PR TITLE
fix(discord-bot): remove GuildPresences intent; add gateway health split

### DIFF
--- a/apps/discord-bot/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/apps/discord-bot/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -118,10 +118,40 @@ mkdir -p config/nginx/ssl
    - Go to
      [Discord Developer Portal](https://discord.com/developers/applications)
    - Create new application
-   - Create bot and get token
-   - Enable necessary intents
+   - Navigate to **Bot** tab → create bot → copy token
 
-2. **Invite Bot to Server**
+2. **Enable Required Privileged Gateway Intents**
+
+   > ⚠️ **CRITICAL**: Without these intents the bot will log "Used disallowed
+   > intents" and disconnect from the gateway. Slash commands and pick delivery
+   > via webhook are **not affected**, but member events and message content
+   > reading will fail.
+
+   In the Discord Developer Portal → **Bot** tab → **Privileged Gateway
+   Intents**:
+
+   | Intent                     | Portal Toggle     | Required For                                       | Enable? |
+   | -------------------------- | ----------------- | -------------------------------------------------- | ------- |
+   | **Server Members Intent**  | `GUILD_MEMBERS`   | Member join/update events, role-change onboarding  | ✅ YES  |
+   | **Message Content Intent** | `MESSAGE_CONTENT` | Reading message text for keyword/emoji DM triggers | ✅ YES  |
+   | **Presence Intent**        | `GUILD_PRESENCES` | (not used — bot does not listen to presenceUpdate) | ❌ NO   |
+
+   **Steps:**
+   1. Go to https://discord.com/developers/applications
+   2. Select your application → **Bot** tab
+   3. Scroll to **Privileged Gateway Intents**
+   4. Toggle **Server Members Intent** → ON
+   5. Toggle **Message Content Intent** → ON
+   6. Leave **Presence Intent** → OFF (not needed; not requested in code)
+   7. Click **Save Changes**
+
+   > **Gateway vs Webhook distinction**: The Discord bot uses a WebSocket
+   > gateway connection for slash commands and member/message events. Pick
+   > delivery (DiscordPromotionAgent) posts via a standalone
+   > `DISCORD_WEBHOOK_URL` and does NOT depend on the bot gateway being
+   > connected. Both health surfaces are reported separately at `GET /health`.
+
+3. **Invite Bot to Server**
    ```
    https://discord.com/api/oauth2/authorize?client_id=YOUR_CLIENT_ID&permissions=8&scope=bot%20applications.commands
    ```

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -10,6 +10,7 @@ if (process.env.NODE_ENV === 'production' && process.env.DOCKER_CONTAINER !== 't
 import 'dotenv/config';
 import { Client, GatewayIntentBits, Partials, GuildMember } from 'discord.js';
 
+
 // REMOVED: AutomatedOnboardingIntegration - nuked as part of clean slate rebuild
 import { AdminCommands } from './commands/adminCommands';
 import { CommandHandler } from './handlers/commandHandler';
@@ -33,6 +34,12 @@ import { RoleChangeService } from './services/roleChangeService';
 import { SupabaseService } from './services/supabase';
 import { VIPNotificationService } from './services/vipNotificationService';
 import { WelcomeService } from './services/welcomeService';
+import {
+  setGatewayConnected,
+  setGatewayConnecting,
+  setGatewayDisconnected,
+  setGatewayError,
+} from './utils/gatewayStatus';
 import { logger } from './utils/logger';
 import { registerCommands } from './utils/registerCommands';
 
@@ -72,12 +79,13 @@ export class UnitTalkBot {
     this.client = new Client({
       intents: [
         GatewayIntentBits.Guilds,
-        GatewayIntentBits.GuildMembers,
+        GatewayIntentBits.GuildMembers, // PRIVILEGED — required: guildMemberAdd, guildMemberUpdate
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.GuildMessageReactions,
         GatewayIntentBits.DirectMessages,
-        GatewayIntentBits.MessageContent,
-        GatewayIntentBits.GuildPresences,
+        GatewayIntentBits.MessageContent, // PRIVILEGED — required: keywordEmojiDMService.processMessageForKeywords (message.content)
+        // GuildPresences removed: presenceUpdate event handler is never registered;
+        // setPresence() for the bot's own status does NOT require this intent.
       ],
       partials: [
         Partials.Message,
@@ -241,8 +249,15 @@ export class UnitTalkBot {
    * Setup Discord event handlers
    */
   private setupEventHandlers(): void {
+    // Gateway connectivity tracking
+    this.client.on('shardReady', () => setGatewayConnected());
+    this.client.on('shardDisconnect', () => setGatewayDisconnected());
+    this.client.on('shardReconnecting', () => setGatewayConnecting());
+    this.client.on('shardError', (err: Error) => setGatewayError(err.message));
+
     // Bot ready event
     this.client.once('ready', async () => {
+      setGatewayConnected();
       console.log(`🤖 Bot online: ${this.client.user?.tag}`);
       console.log(`🏠 Serving ${this.client.guilds.cache.size} guilds`);
       logger.info(`Bot logged in as ${this.client.user?.tag}`);

--- a/apps/discord-bot/src/routes/health.ts
+++ b/apps/discord-bot/src/routes/health.ts
@@ -9,6 +9,7 @@ import Redis from 'ioredis';
 import { SupabaseService } from '../services/supabase';
 import { toISOString } from '../utils/dateUtils';
 import { HealthChecker, PerformanceMonitor, logger } from '../utils/enterpriseErrorHandling';
+import { getGatewayStatus, isGatewayConnected } from '../utils/gatewayStatus';
 
 const router: Router = express.Router();
 const healthChecker = new HealthChecker();
@@ -79,7 +80,8 @@ router.get('/health/detailed', async (_req: Request, res: Response) => {
 router.get('/ready', async (_req: Request, res: Response) => {
   try {
     // Check critical dependencies
-    const criticalChecks = ['database', 'discord', 'redis'];
+    // discord_api: REST reachability; discord_gateway: WebSocket connection
+    const criticalChecks = ['database', 'discord_api', 'discord_gateway', 'redis'];
     const health = await healthChecker.getOverallHealth();
 
     const criticalStatus = criticalChecks.every(
@@ -225,11 +227,10 @@ function initializeHealthChecks(): void {
     }
   });
 
-  // Discord API health check
-  healthChecker.addCheck('discord', async () => {
+  // Discord REST API health check (does NOT reflect gateway/WebSocket connection)
+  healthChecker.addCheck('discord_api', async () => {
     const startTime = performance.now();
     try {
-      // Simple Discord API health check
       const response = await fetch('https://discord.com/api/v10/gateway', {
         method: 'GET',
         headers: {
@@ -248,6 +249,7 @@ function initializeHealthChecks(): void {
           details: {
             error: `Discord API returned ${response.status}`,
             status: response.status,
+            note: 'REST API reachability only — see discord_gateway for WebSocket connection',
           },
         };
       }
@@ -259,6 +261,7 @@ function initializeHealthChecks(): void {
         details: {
           responseTime: `${Math.round(duration)}ms`,
           status: response.status,
+          note: 'REST API reachability only — see discord_gateway for WebSocket connection',
         },
       };
     } catch (error) {
@@ -269,6 +272,26 @@ function initializeHealthChecks(): void {
         details: { error: error instanceof Error ? error.message : 'Discord API check failed' },
       };
     }
+  });
+
+  // Discord WebSocket gateway connectivity check (bot is CONNECTED to Discord gateway)
+  // This is separate from webhook posting (DiscordPromotionAgent uses standalone webhook URL).
+  healthChecker.addCheck('discord_gateway', async () => {
+    const snapshot = getGatewayStatus();
+    const connected = isGatewayConnected();
+
+    return {
+      status: connected ? 'healthy' : snapshot.state === 'connecting' ? 'degraded' : 'unhealthy',
+      timestamp: toISOString(new Date()),
+      duration: 0,
+      details: {
+        state: snapshot.state,
+        connectedAt: snapshot.connectedAt,
+        lastError: snapshot.lastError,
+        lastErrorAt: snapshot.lastErrorAt,
+        note: 'WebSocket gateway connection — required for slash commands, member events, message events. Webhook posting (pick delivery) does NOT depend on this.',
+      },
+    };
   });
 
   // Memory health check

--- a/apps/discord-bot/src/utils/gatewayStatus.ts
+++ b/apps/discord-bot/src/utils/gatewayStatus.ts
@@ -1,0 +1,57 @@
+/**
+ * gatewayStatus.ts
+ *
+ * Singleton that tracks the Discord WebSocket gateway connection state.
+ * Updated by the bot's ready/disconnect/error events; read by the health check.
+ *
+ * This separates gateway connectivity truth from Discord REST API reachability.
+ * Webhook posting (DiscordPromotionAgent) does NOT depend on this bot's gateway
+ * connection — it uses a standalone webhook URL via the API service.
+ */
+
+export type GatewayState = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+interface GatewayStatusSnapshot {
+  state: GatewayState;
+  connectedAt: string | null;
+  lastErrorAt: string | null;
+  lastError: string | null;
+}
+
+let currentState: GatewayState = 'disconnected';
+let connectedAt: string | null = null;
+let lastErrorAt: string | null = null;
+let lastError: string | null = null;
+
+export function setGatewayConnected(): void {
+  currentState = 'connected';
+  connectedAt = new Date().toISOString();
+  lastError = null;
+}
+
+export function setGatewayDisconnected(): void {
+  currentState = 'disconnected';
+}
+
+export function setGatewayConnecting(): void {
+  currentState = 'connecting';
+}
+
+export function setGatewayError(error: string): void {
+  currentState = 'error';
+  lastErrorAt = new Date().toISOString();
+  lastError = error;
+}
+
+export function getGatewayStatus(): GatewayStatusSnapshot {
+  return {
+    state: currentState,
+    connectedAt,
+    lastErrorAt,
+    lastError,
+  };
+}
+
+export function isGatewayConnected(): boolean {
+  return currentState === 'connected';
+}

--- a/governance/closeouts/SPRINT-DISCORD-GATEWAY-INTENTS-ENABLEMENT.md
+++ b/governance/closeouts/SPRINT-DISCORD-GATEWAY-INTENTS-ENABLEMENT.md
@@ -1,0 +1,28 @@
+# Sprint Closeout: SPRINT-DISCORD-GATEWAY-INTENTS-ENABLEMENT
+
+**Date**: 2026-03-14 **Status**: COMPLETE **Linear**: TBD **Branch**:
+sprint/discord-gateway-intents-enablement → main
+
+## Summary
+
+Resolved Discord gateway disconnection ("Used disallowed intents") by removing
+unnecessary `GatewayIntentBits.GuildPresences` from bot client configuration.
+Added gateway connectivity status singleton and split health monitoring into
+`discord_api` (REST) and `discord_gateway` (WebSocket) checks. Documented
+explicit privileged intent requirements in PRODUCTION_DEPLOYMENT_GUIDE.md.
+
+## Verification
+
+- TypeScript: 0 errors
+- Lifecycle gate: 988 files scanned, 0 violations, PASS
+- GuildPresences removed from intents (3 privileged → 2 privileged)
+- discord_gateway health check added to /health and /ready
+
+## Remaining Operator Action
+
+Enable Server Members Intent + Message Content Intent in Discord Developer
+Portal (documented in HANDOFF_SUMMARY.md and PRODUCTION_DEPLOYMENT_GUIDE.md).
+
+## Proof Location
+
+out/sprints/SPRINT-DISCORD-GATEWAY-INTENTS-ENABLEMENT/2026-03-14/


### PR DESCRIPTION
## Summary

- **Root cause fix**: Remove `GatewayIntentBits.GuildPresences` from bot intents — `presenceUpdate` event was never registered; requesting an unenabled privileged intent causes Discord to reject the gateway handshake with "Used disallowed intents"
- **New**: `src/utils/gatewayStatus.ts` — singleton tracking real WebSocket connection state (connected/disconnected/connecting/error)
- **Health split**: `discord` check → `discord_api` (REST) + `discord_gateway` (WS). Both in `/ready` critical checks
- **Docs**: `PRODUCTION_DEPLOYMENT_GUIDE.md` — explicit privileged intent table (Server Members ✅, Message Content ✅, Presence ❌)

## Operator action still required (after merge)
Enable in Discord Developer Portal → Bot → Privileged Gateway Intents:
- Server Members Intent → ON
- Message Content Intent → ON  
- Presence Intent → OFF (not needed)

See: `out/sprints/SPRINT-DISCORD-GATEWAY-INTENTS-ENABLEMENT/2026-03-14/HANDOFF_SUMMARY.md`

## Test plan
- [ ] TypeScript: 0 errors ✅
- [ ] Lifecycle gate: 0 violations ✅
- [ ] After portal step: `GET /health` → `discord_gateway.state: "connected"`
- [ ] After portal step: `GET /ready` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)