### PR TITLE
chore(governance): closeout SPRINT-CLAUDE-OS-LIFECYCLE-AUTOMATION-HARDENING

### DIFF
--- a/governance/closeouts/SPRINT-CLAUDE-OS-LIFECYCLE-AUTOMATION-HARDENING.md
+++ b/governance/closeouts/SPRINT-CLAUDE-OS-LIFECYCLE-AUTOMATION-HARDENING.md
@@ -1,0 +1,25 @@
+# Governance Closeout — SPRINT-CLAUDE-OS-LIFECYCLE-AUTOMATION-HARDENING
+
+**Sprint**: SPRINT-CLAUDE-OS-LIFECYCLE-AUTOMATION-HARDENING **Date**: 2026-03-14
+**Merged**: PR #201 → main (2872798b) **Status**: COMPLETE
+
+## Summary
+
+Added `tools/claude-os/src/lifecycle-checker.ts` — a read-only module checking 5
+post-bundle lifecycle gates (proof artifacts, bundle verdict, working tree, tag
+on remote, status sync) with priority-ordered operator next steps.
+
+Added `lifecycle-status` CLI command to Claude OS.
+
+## Verification Gates
+
+- claude-os tsc: Exit 0
+- apps/api tsc: Exit 0
+- vitest: 926/926 passing (36 suites)
+- single-writer gate: 995 files scanned, 0 violations
+
+## Files Changed
+
+- `tools/claude-os/src/lifecycle-checker.ts` (NEW)
+- `tools/claude-os/src/cli.ts` (Modified — lifecycle-status command)
+- `docs/02_architecture/claude_os_lifecycle_automation.md` (NEW)


### PR DESCRIPTION
## Summary

Governance closeout for SPRINT-CLAUDE-OS-LIFECYCLE-AUTOMATION-HARDENING.

Adds `governance/closeouts/SPRINT-CLAUDE-OS-LIFECYCLE-AUTOMATION-HARDENING.md` to trigger CI tag minting.

Sprint was merged via PR #201 (2872798b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)