### PR TITLE
feat(claude-os): COS-007 — LLM routing decision validation in sprint:close

### DIFF
--- a/governance/closeouts/SPRINT-COS-007-SPRINT-CLOSE-VALIDATION.md
+++ b/governance/closeouts/SPRINT-COS-007-SPRINT-CLOSE-VALIDATION.md
@@ -1,0 +1,13 @@
+# Closeout: SPRINT-COS-007-SPRINT-CLOSE-VALIDATION
+
+**Sprint**: SPRINT-COS-007-SPRINT-CLOSE-VALIDATION **Date**: 2026-03-15
+**Status**: COMPLETE **Proof**:
+out/sprints/SPRINT-COS-007-SPRINT-CLOSE-VALIDATION/2026-03-15/SPRINT_CLOSEOUT_REPORT.md
+
+## Summary
+
+COS-007 complete: `sprint:close` now validates `LLM_ROUTING_DECISION.md`
+presence and well-formedness (Sprint, Classifications, Instance mode, Lane
+assignments) before closing. Bypassed by `--force`. 17 vitest tests added;
+532/532 passing. Closes the full COS-001 through COS-007 Claude OS upgrade
+batch.

--- a/tools/claude-os/src/__tests__/routing-decision-validator.test.ts
+++ b/tools/claude-os/src/__tests__/routing-decision-validator.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for routing-decision-validator.ts (COS-007)
+ *
+ * Test groups:
+ *   1. findRoutingDecisionFile — file discovery
+ *   2. validateRoutingDecision — missing sprint output directory
+ *   3. validateRoutingDecision — missing file
+ *   4. validateRoutingDecision — valid file passes
+ *   5. validateRoutingDecision — missing required fields
+ *   6. validateRoutingDecision — partial missing fields
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { findRoutingDecisionFile, validateRoutingDecision } from '../routing-decision-validator.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-os-routing-validator-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Write LLM_ROUTING_DECISION.md into out/sprints/<sprint>/<date>/ under tmpDir */
+function writeRoutingDecision(sprintId: string, dateDir: string, content: string): string {
+  const dir = path.join(tmpDir, 'out', 'sprints', sprintId, dateDir);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, 'LLM_ROUTING_DECISION.md');
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+const VALID_ROUTING_DECISION = `# LLM Routing Decision — SPRINT-TEST-001
+
+**Generated**: 2026-03-15T00:00:00.000Z
+**Sprint**: SPRINT-TEST-001
+**Sprint Type**: feature
+
+---
+
+## 1. Classification Result
+
+**Classifications**: implementation
+
+---
+
+## 2. Lanes Selected
+
+| Lane | Name | Preferred Model | Execution Mode | External? |
+|------|------|----------------|----------------|-----------|
+| 1 | Implementation | Claude Sonnet | Claude Code internal | None |
+| 3 | Verification | Claude Sonnet | Claude Code internal | None |
+
+---
+
+## 4. Instance Recommendation
+
+**Mode**: SINGLE_INSTANCE
+
+**Rationale**: Mode A — single-LLM execution.
+`;
+
+const SPRINT_ID = 'SPRINT-TEST-001';
+const opts = () => ({ repoRoot: tmpDir });
+
+// ---------------------------------------------------------------------------
+// 1. findRoutingDecisionFile
+// ---------------------------------------------------------------------------
+
+describe('findRoutingDecisionFile', () => {
+  it('returns null when sprint directory does not exist', () => {
+    expect(findRoutingDecisionFile('SPRINT-MISSING', opts())).toBeNull();
+  });
+
+  it('returns null when sprint directory exists but has no date subdirs', () => {
+    fs.mkdirSync(path.join(tmpDir, 'out', 'sprints', SPRINT_ID), { recursive: true });
+    expect(findRoutingDecisionFile(SPRINT_ID, opts())).toBeNull();
+  });
+
+  it('returns null when date subdirs exist but contain no routing decision file', () => {
+    fs.mkdirSync(path.join(tmpDir, 'out', 'sprints', SPRINT_ID, '2026-03-15'), {
+      recursive: true,
+    });
+    expect(findRoutingDecisionFile(SPRINT_ID, opts())).toBeNull();
+  });
+
+  it('returns the absolute path when the file exists', () => {
+    const filePath = writeRoutingDecision(SPRINT_ID, '2026-03-15', VALID_ROUTING_DECISION);
+    expect(findRoutingDecisionFile(SPRINT_ID, opts())).toBe(filePath);
+  });
+
+  it('returns the most-recent date directory first when multiple exist', () => {
+    writeRoutingDecision(SPRINT_ID, '2026-03-14', '# old');
+    const newer = writeRoutingDecision(SPRINT_ID, '2026-03-15', VALID_ROUTING_DECISION);
+    expect(findRoutingDecisionFile(SPRINT_ID, opts())).toBe(newer);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Missing sprint output directory
+// ---------------------------------------------------------------------------
+
+describe('validateRoutingDecision — missing sprint directory', () => {
+  it('returns valid=false with descriptive error', () => {
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(false);
+    expect(result.filePath).toBeNull();
+    expect(result.errors.some(e => e.includes('not found'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Missing file
+// ---------------------------------------------------------------------------
+
+describe('validateRoutingDecision — missing file', () => {
+  it('returns valid=false when directory exists but file is absent', () => {
+    fs.mkdirSync(path.join(tmpDir, 'out', 'sprints', SPRINT_ID, '2026-03-15'), {
+      recursive: true,
+    });
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(false);
+    expect(result.filePath).toBeNull();
+    expect(result.errors.some(e => e.includes('LLM_ROUTING_DECISION.md not found'))).toBe(true);
+  });
+
+  it('includes hint to run the router in the error message', () => {
+    fs.mkdirSync(path.join(tmpDir, 'out', 'sprints', SPRINT_ID, '2026-03-15'), {
+      recursive: true,
+    });
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.errors.some(e => e.includes('route'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Valid file passes
+// ---------------------------------------------------------------------------
+
+describe('validateRoutingDecision — valid file', () => {
+  it('returns valid=true for a well-formed routing decision', () => {
+    writeRoutingDecision(SPRINT_ID, '2026-03-15', VALID_ROUTING_DECISION);
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.filePath).not.toBeNull();
+  });
+
+  it('returns the absolute path to the file', () => {
+    const filePath = writeRoutingDecision(SPRINT_ID, '2026-03-15', VALID_ROUTING_DECISION);
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.filePath).toBe(filePath);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Missing required fields — all absent
+// ---------------------------------------------------------------------------
+
+describe('validateRoutingDecision — all required fields missing', () => {
+  it('reports errors for all four required fields', () => {
+    writeRoutingDecision(SPRINT_ID, '2026-03-15', '# LLM Routing Decision\n\nNo required content.');
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Partial missing fields
+// ---------------------------------------------------------------------------
+
+describe('validateRoutingDecision — partial missing fields', () => {
+  it('fails when Sprint identifier is missing', () => {
+    const content = VALID_ROUTING_DECISION.replace('**Sprint**: SPRINT-TEST-001', '');
+    writeRoutingDecision(SPRINT_ID, '2026-03-15', content);
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Sprint identifier'))).toBe(true);
+  });
+
+  it('fails when Classifications are missing', () => {
+    const content = VALID_ROUTING_DECISION.replace('**Classifications**: implementation', '');
+    writeRoutingDecision(SPRINT_ID, '2026-03-15', content);
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Work type'))).toBe(true);
+  });
+
+  it('fails when Instance mode is missing', () => {
+    const content = VALID_ROUTING_DECISION.replace('SINGLE_INSTANCE', 'UNSET');
+    writeRoutingDecision(SPRINT_ID, '2026-03-15', content);
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Instance mode'))).toBe(true);
+  });
+
+  it('fails when Lane assignments are missing', () => {
+    // Remove the table header row
+    const content = VALID_ROUTING_DECISION.replace('| Lane | Name |', '| — | — |');
+    writeRoutingDecision(SPRINT_ID, '2026-03-15', content);
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Lane assignments'))).toBe(true);
+  });
+
+  it('passes with TWO_INSTANCES as instance mode', () => {
+    const content = VALID_ROUTING_DECISION.replace('SINGLE_INSTANCE', 'TWO_INSTANCES');
+    writeRoutingDecision(SPRINT_ID, '2026-03-15', content);
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes with THREE_INSTANCES as instance mode', () => {
+    const content = VALID_ROUTING_DECISION.replace('SINGLE_INSTANCE', 'THREE_INSTANCES');
+    writeRoutingDecision(SPRINT_ID, '2026-03-15', content);
+    const result = validateRoutingDecision(SPRINT_ID, opts());
+    expect(result.valid).toBe(true);
+  });
+});

--- a/tools/claude-os/src/cli.ts
+++ b/tools/claude-os/src/cli.ts
@@ -52,6 +52,7 @@ import { loadProfileById, loadProfileFromPath } from './profile-loader.js';
 import { generatePromptPack } from './prompt-pack-generator.js';
 import { scanIssueQueue, selectNextIssue } from './queue-manager.js';
 import { validateAllReceipts } from './receipt-validator.js';
+import { validateRoutingDecision } from './routing-decision-validator.js';
 import { resolveBlastRadius } from './scope-resolver.js';
 import { assembleSprintPlan, assembleSprintPlanWithProfile } from './sprint-planner.js';
 import {
@@ -2350,6 +2351,29 @@ function commandSprintClose(args: Record<string, string | boolean | string[]>): 
       }
       if (jsonOutput)
         console.log(JSON.stringify({ error: 'receipt_validation_failed', validation }, null, 2));
+      process.exit(1);
+    }
+  }
+
+  // LLM routing decision gate — runs BEFORE authority lock release
+  // Skipped when --force is set (same as receipt validation gate)
+  if (!force) {
+    const routingValidation = validateRoutingDecision(state.sprint_id);
+    if (!routingValidation.valid) {
+      console.error(
+        `${c.red}ERROR: LLM routing decision validation failed — cannot close sprint.${c.reset}`
+      );
+      for (const err of routingValidation.errors) {
+        console.error(`  ${c.red}→ ${err}${c.reset}`);
+      }
+      if (jsonOutput)
+        console.log(
+          JSON.stringify(
+            { error: 'routing_decision_validation_failed', errors: routingValidation.errors },
+            null,
+            2
+          )
+        );
       process.exit(1);
     }
   }

--- a/tools/claude-os/src/routing-decision-validator.ts
+++ b/tools/claude-os/src/routing-decision-validator.ts
@@ -1,0 +1,156 @@
+/**
+ * Routing Decision Validator (COS-007)
+ *
+ * Validates that a well-formed LLM_ROUTING_DECISION.md exists in the sprint
+ * output directory before sprint:close is allowed to complete.
+ *
+ * Required fields (checked by markdown content scan):
+ *   - Sprint identifier
+ *   - Work type(s) / classifications
+ *   - Instance mode (SINGLE_INSTANCE | TWO_INSTANCES | THREE_INSTANCES)
+ *   - Lane assignments (at least one lane entry)
+ *
+ * File location convention:
+ *   out/sprints/<sprint_id>/<YYYY-MM-DD>/LLM_ROUTING_DECISION.md
+ *
+ * When multiple date directories exist, the most recently named (lexicographic
+ * sort descending) directory is checked first.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { resolveRepoPath } from './fs-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RoutingDecisionValidationResult {
+  /** Whether the routing decision is present and well-formed */
+  valid: boolean;
+  /** Absolute path to the file that was found (null if not found) */
+  filePath: string | null;
+  /** Validation errors — empty when valid=true */
+  errors: string[];
+}
+
+/** Options for overriding paths in tests */
+export interface RoutingDecisionValidatorOptions {
+  /** Override repo root for resolving out/sprints/ (useful in tests) */
+  repoRoot?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Required field patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Each entry is [fieldName, regex] — the regex is tested against the full file
+ * content. A failing match produces an error for that field.
+ */
+const REQUIRED_FIELD_PATTERNS: Array<[string, RegExp]> = [
+  ['Sprint identifier', /\*\*Sprint\*\*:/m],
+  ['Work type(s) / Classifications', /\*\*Classifications\*\*:/im],
+  ['Instance mode', /SINGLE_INSTANCE|TWO_INSTANCES|THREE_INSTANCES/],
+  ['Lane assignments', /\| Lane /m],
+];
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Locate LLM_ROUTING_DECISION.md in the sprint output directory.
+ * Searches all date-subdirectories (most recent first).
+ * Returns the absolute path of the first match, or null.
+ */
+export function findRoutingDecisionFile(
+  sprintId: string,
+  options?: RoutingDecisionValidatorOptions
+): string | null {
+  const resolve = (p: string) =>
+    options?.repoRoot ? path.join(options.repoRoot, p) : resolveRepoPath(p);
+
+  const sprintsDir = resolve(`out/sprints/${sprintId}`);
+  if (!fs.existsSync(sprintsDir)) return null;
+
+  let dateDirs: string[];
+  try {
+    dateDirs = fs
+      .readdirSync(sprintsDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name)
+      .sort()
+      .reverse(); // most-recent date string first
+  } catch {
+    return null;
+  }
+
+  for (const dateDir of dateDirs) {
+    const candidate = path.join(sprintsDir, dateDir, 'LLM_ROUTING_DECISION.md');
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that a well-formed LLM_ROUTING_DECISION.md exists for the given
+ * sprint.
+ *
+ * Returns { valid: true } when the file is found and all required fields are
+ * present. Returns { valid: false, errors } otherwise.
+ */
+export function validateRoutingDecision(
+  sprintId: string,
+  options?: RoutingDecisionValidatorOptions
+): RoutingDecisionValidationResult {
+  const resolve = (p: string) =>
+    options?.repoRoot ? path.join(options.repoRoot, p) : resolveRepoPath(p);
+
+  const sprintsDir = resolve(`out/sprints/${sprintId}`);
+  if (!fs.existsSync(sprintsDir)) {
+    return {
+      valid: false,
+      filePath: null,
+      errors: [`Sprint output directory not found: out/sprints/${sprintId}/`],
+    };
+  }
+
+  const filePath = findRoutingDecisionFile(sprintId, options);
+  if (!filePath) {
+    return {
+      valid: false,
+      filePath: null,
+      errors: [
+        `LLM_ROUTING_DECISION.md not found in out/sprints/${sprintId}/*/`,
+        'Run the LLM router before closing: npx tsx tools/claude-os/src/cli.ts route --sprint <ID> ...',
+      ],
+    };
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return {
+      valid: false,
+      filePath,
+      errors: [`Failed to read ${filePath}`],
+    };
+  }
+
+  const errors: string[] = [];
+  for (const [fieldName, pattern] of REQUIRED_FIELD_PATTERNS) {
+    if (!pattern.test(content)) {
+      errors.push(`Missing required field in LLM_ROUTING_DECISION.md: ${fieldName}`);
+    }
+  }
+
+  return { valid: errors.length === 0, filePath, errors };
+}


### PR DESCRIPTION
## Summary

- New module `tools/claude-os/src/routing-decision-validator.ts` — finds `LLM_ROUTING_DECISION.md` in `out/sprints/<id>/*/` and validates four required fields: Sprint identifier, Work type(s)/Classifications, Instance mode, Lane assignments
- Integrated into `commandSprintClose()` after receipt validation, before authority lock release
- Respects `--force` flag (same as receipt validation gate)
- 17 vitest tests added; 532/532 passing
- Closes the **COS-001 through COS-007** Claude OS upgrade batch

**Linear**: UNI-83

## Test plan

- [x] `npm test` in `tools/claude-os/` — 532/532 passing (38 test files)
- [x] `npm run type-check` — 0 errors across all workspaces
- [x] `npm run lifecycle:single-writer -- --strict` — 0 violations (998 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)