### PR TITLE
feat(smart-form): accessibility polish and keyboard shortcuts — SPRINT-051

### DIFF
--- a/apps/smart-form/app/submit-ticket/components/BetSlipPanel.tsx
+++ b/apps/smart-form/app/submit-ticket/components/BetSlipPanel.tsx
@@ -122,19 +122,34 @@ function LegItem({ leg, onRemove, onUpdate }: LegItemProps) {
           <div className="flex items-center justify-between">
             <span className="text-xs text-gray-500 uppercase">{leg.sport}</span>
             <div className="flex gap-1">
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={handleSave}>
-                <Check className="h-3 w-3 text-green-600" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={handleSave}
+                aria-label="Save leg edits"
+              >
+                <Check className="h-3 w-3 text-green-600" aria-hidden="true" />
               </Button>
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={handleCancel}>
-                <X className="h-3 w-3 text-gray-400" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={handleCancel}
+                aria-label="Cancel leg edits"
+              >
+                <X className="h-3 w-3 text-gray-400" aria-hidden="true" />
               </Button>
             </div>
           </div>
           <p className="text-sm font-medium truncate">{leg.player_name || leg.team}</p>
           <div className="flex gap-2">
             <div className="flex-1">
-              <label className="text-xs text-gray-500">Line</label>
+              <label htmlFor={`edit-line-${leg.id}`} className="text-xs text-gray-500">
+                Line
+              </label>
               <Input
+                id={`edit-line-${leg.id}`}
                 type="number"
                 step="0.5"
                 value={editLine}
@@ -144,8 +159,11 @@ function LegItem({ leg, onRemove, onUpdate }: LegItemProps) {
               />
             </div>
             <div className="flex-1">
-              <label className="text-xs text-gray-500">Odds</label>
+              <label htmlFor={`edit-odds-${leg.id}`} className="text-xs text-gray-500">
+                Odds
+              </label>
               <Input
+                id={`edit-odds-${leg.id}`}
                 value={editOdds}
                 onChange={e => setEditOdds(e.target.value)}
                 className="h-8 text-sm"
@@ -188,16 +206,18 @@ function LegItem({ leg, onRemove, onUpdate }: LegItemProps) {
               size="icon"
               className="h-7 w-7 text-gray-400 hover:text-blue-600"
               onClick={() => setIsEditing(true)}
+              aria-label={`Edit ${buildSelectionString(leg)}`}
             >
-              <Edit2 className="h-3.5 w-3.5" />
+              <Edit2 className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
             <Button
               variant="ghost"
               size="icon"
               className="h-7 w-7 text-gray-400 hover:text-red-600"
               onClick={onRemove}
+              aria-label={`Remove ${buildSelectionString(leg)}`}
             >
-              <Trash2 className="h-3.5 w-3.5" />
+              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
           </div>
         </div>

--- a/apps/smart-form/app/submit-ticket/components/GamePickForm.tsx
+++ b/apps/smart-form/app/submit-ticket/components/GamePickForm.tsx
@@ -178,8 +178,14 @@ export function GamePickForm({
       {/* Bet type selector for parlays */}
       {isMultiLegTicket && (
         <div>
-          <label className="text-xs font-medium text-muted-foreground mb-1 block">Bet Type</label>
+          <label
+            htmlFor="gpf-bet-type"
+            className="text-xs font-medium text-muted-foreground mb-1 block"
+          >
+            Bet Type
+          </label>
           <select
+            id="gpf-bet-type"
             value={legBetType}
             onChange={e => setLegBetType(e.target.value)}
             className="flex h-10 w-full items-center rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
@@ -194,11 +200,18 @@ export function GamePickForm({
       )}
 
       <div>
-        <label className="text-xs font-medium text-muted-foreground mb-1 block">Selection</label>
+        <label
+          htmlFor="gpf-selection"
+          className="text-xs font-medium text-muted-foreground mb-1 block"
+        >
+          Selection
+        </label>
         <select
+          id="gpf-selection"
           value={selection}
           onChange={e => handleSelectionChange(e.target.value)}
           className="flex h-10 w-full items-center rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          aria-required="true"
         >
           <option value="">Choose your pick</option>
           {availableSelections.map(opt => (
@@ -211,12 +224,19 @@ export function GamePickForm({
 
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="text-xs font-medium text-muted-foreground mb-1 block">Odds</label>
+          <label
+            htmlFor="gpf-odds"
+            className="text-xs font-medium text-muted-foreground mb-1 block"
+          >
+            Odds
+          </label>
           <Input
+            id="gpf-odds"
             type="number"
             placeholder="-110"
             value={odds}
             onChange={e => setOdds(e.target.value)}
+            aria-required="true"
           />
         </div>
         {(effectiveBetType === 'spread' ||
@@ -224,8 +244,14 @@ export function GamePickForm({
           effectiveBetType === 'team_total' ||
           effectiveBetType === 'player_prop') && (
           <div>
-            <label className="text-xs font-medium text-muted-foreground mb-1 block">Line</label>
+            <label
+              htmlFor="gpf-line"
+              className="text-xs font-medium text-muted-foreground mb-1 block"
+            >
+              Line
+            </label>
             <Input
+              id="gpf-line"
               type="number"
               step="0.5"
               placeholder="8.5"

--- a/apps/smart-form/app/submit-ticket/components/KeyboardShortcutsHelp.tsx
+++ b/apps/smart-form/app/submit-ticket/components/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * KeyboardShortcutsHelp
+ *
+ * SPRINT-051-LAYER3-PHASE9-SMARTFORM-UX-POLISH
+ *
+ * Documents and surfaces existing keyboard shortcuts available in the
+ * Smart Form submission flow. Toggles open/closed via a help button.
+ */
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Keyboard, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ShortcutEntry {
+  keys: string[];
+  description: string;
+  context: string;
+}
+
+const SHORTCUTS: ShortcutEntry[] = [
+  {
+    keys: ['Enter'],
+    description: 'Add current leg to bet slip',
+    context: 'Bet builder — when a capper and leg details are filled in',
+  },
+  {
+    keys: ['Esc'],
+    description: 'Clear the current leg form',
+    context: 'Bet builder — resets sport, teams, and selection fields',
+  },
+  {
+    keys: ['↑', '↓'],
+    description: 'Navigate player suggestions',
+    context: 'Player search dropdown — move between results',
+  },
+  {
+    keys: ['Enter'],
+    description: 'Select highlighted player',
+    context: 'Player search dropdown — confirms the focused suggestion',
+  },
+  {
+    keys: ['Esc'],
+    description: 'Close player suggestions',
+    context: 'Player search dropdown — dismiss without selecting',
+  },
+];
+
+export function KeyboardShortcutsHelp({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className={cn('relative', className)}>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen(prev => !prev)}
+        aria-label={open ? 'Close keyboard shortcuts help' : 'Show keyboard shortcuts'}
+        aria-expanded={open}
+        aria-controls="keyboard-shortcuts-panel"
+        className="h-8 px-2 text-slate-400 hover:text-slate-200 hover:bg-slate-700"
+      >
+        <Keyboard className="h-4 w-4 mr-1.5" aria-hidden="true" />
+        <span className="text-xs">Shortcuts</span>
+      </Button>
+
+      {open && (
+        <div
+          id="keyboard-shortcuts-panel"
+          role="dialog"
+          aria-label="Keyboard shortcuts"
+          aria-modal="false"
+          className={cn(
+            'absolute right-0 top-9 z-50 w-80',
+            'bg-slate-800 border border-slate-600 rounded-lg shadow-xl',
+            'p-4'
+          )}
+        >
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-semibold text-white flex items-center gap-2">
+              <Keyboard className="h-4 w-4" aria-hidden="true" />
+              Keyboard Shortcuts
+            </h3>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 text-slate-400 hover:text-white"
+              onClick={() => setOpen(false)}
+              aria-label="Close keyboard shortcuts"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          </div>
+
+          <ul className="space-y-3" role="list">
+            {SHORTCUTS.map((shortcut, idx) => (
+              <li key={idx} className="text-xs">
+                <div className="flex items-start gap-2">
+                  <div className="flex gap-1 shrink-0 mt-0.5">
+                    {shortcut.keys.map((key, ki) => (
+                      <kbd
+                        key={ki}
+                        className={cn(
+                          'inline-flex items-center justify-center',
+                          'h-5 min-w-[20px] px-1',
+                          'bg-slate-700 border border-slate-500 rounded',
+                          'text-[10px] font-mono text-slate-200'
+                        )}
+                      >
+                        {key}
+                      </kbd>
+                    ))}
+                  </div>
+                  <div>
+                    <p className="text-slate-200 font-medium">{shortcut.description}</p>
+                    <p className="text-slate-400 mt-0.5">{shortcut.context}</p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/smart-form/app/submit-ticket/components/ManualEntryForm.tsx
+++ b/apps/smart-form/app/submit-ticket/components/ManualEntryForm.tsx
@@ -382,8 +382,13 @@ export function ManualEntryForm({
 
   // Error banner component
   const ErrorBanner = ({ message, onRetry }: { message: string; onRetry?: () => void }) => (
-    <div className="flex items-center gap-2 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">
-      <AlertTriangle className="h-4 w-4 shrink-0" />
+    <div
+      role="alert"
+      aria-live="polite"
+      aria-atomic="true"
+      className="flex items-center gap-2 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm"
+    >
+      <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
       <span className="flex-1">{message}</span>
       {onRetry && (
         <Button
@@ -392,7 +397,7 @@ export function ManualEntryForm({
           onClick={onRetry}
           className="text-red-700 hover:text-red-900 hover:bg-red-100 shrink-0"
         >
-          <RefreshCw className="h-3.5 w-3.5 mr-1" />
+          <RefreshCw className="h-3.5 w-3.5 mr-1" aria-hidden="true" />
           Retry
         </Button>
       )}
@@ -405,33 +410,49 @@ export function ManualEntryForm({
     side: 'home' | 'away',
     value: string,
     onChange: (v: string) => void
-  ) => (
-    <div>
-      <label className="text-xs font-medium text-muted-foreground mb-1 block">{label}</label>
-      {teamsLoading ? (
-        <div className="flex items-center gap-2 h-10 px-3 border border-border rounded-md bg-muted">
-          <div className="animate-spin h-4 w-4 border-2 border-primary rounded-full border-t-transparent" />
-          <span className="text-sm text-muted-foreground">Loading teams...</span>
-        </div>
-      ) : teamsError ? (
-        <ErrorBanner message={teamsError} onRetry={loadTeams} />
-      ) : teamItems.length > 0 ? (
-        <Combobox
-          items={teamItems}
-          value={value}
-          onValueChange={onChange}
-          placeholder={getPlaceholder(sport, side)}
-          searchPlaceholder="Search teams..."
-          emptyText="No teams found"
-          loading={teamsLoading}
-        />
-      ) : (
-        <div className="flex items-center h-10 px-3 border border-border rounded-md bg-muted">
-          <span className="text-sm text-muted-foreground">No teams found for this sport</span>
-        </div>
-      )}
-    </div>
-  );
+  ) => {
+    const fieldId = `team-${side}`;
+    return (
+      <div>
+        <label htmlFor={fieldId} className="text-xs font-medium text-muted-foreground mb-1 block">
+          {label}
+        </label>
+        {teamsLoading ? (
+          <div
+            id={fieldId}
+            role="status"
+            aria-label={`Loading ${label} options`}
+            className="flex items-center gap-2 h-10 px-3 border border-border rounded-md bg-muted"
+          >
+            <div
+              className="animate-spin h-4 w-4 border-2 border-primary rounded-full border-t-transparent"
+              aria-hidden="true"
+            />
+            <span className="text-sm text-muted-foreground">Loading teams...</span>
+          </div>
+        ) : teamsError ? (
+          <ErrorBanner message={teamsError} onRetry={loadTeams} />
+        ) : teamItems.length > 0 ? (
+          <Combobox
+            items={teamItems}
+            value={value}
+            onValueChange={onChange}
+            placeholder={getPlaceholder(sport, side)}
+            searchPlaceholder="Search teams..."
+            emptyText="No teams found"
+            loading={teamsLoading}
+          />
+        ) : (
+          <div
+            id={fieldId}
+            className="flex items-center h-10 px-3 border border-border rounded-md bg-muted"
+          >
+            <span className="text-sm text-muted-foreground">No teams found for this sport</span>
+          </div>
+        )}
+      </div>
+    );
+  };
 
   // Bet type selector for multi-leg tickets
   const BetTypeSelector = () =>

--- a/apps/smart-form/app/submit-ticket/components/SportsbookManualEntry.tsx
+++ b/apps/smart-form/app/submit-ticket/components/SportsbookManualEntry.tsx
@@ -29,6 +29,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { Spinner } from '@/components/ui/spinner';
 import { Plus, Trash2, Check, AlertCircle, Copy, RefreshCw, X, Search, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
 
 import {
   submitTicketV3,
@@ -886,11 +887,14 @@ export function SportsbookManualEntry() {
     <div className="min-h-screen bg-[#1a1d24]" onKeyDown={handleKeyDown}>
       <div className="max-w-7xl mx-auto px-4 py-6">
         {/* Header */}
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-white">Smart Manual Entry</h1>
-          <p className="text-slate-400 text-sm mt-1">
-            Select capper + teams • Enter to add • Esc to clear
-          </p>
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-white">Smart Manual Entry</h1>
+            <p className="text-slate-400 text-sm mt-1">
+              Select capper + teams • Enter to add • Esc to clear
+            </p>
+          </div>
+          <KeyboardShortcutsHelp className="shrink-0 mt-1" />
         </div>
 
         {/* SPRINT-093: Discord Routing Warning */}

--- a/apps/smart-form/tests/keyboard-shortcuts-help.test.tsx
+++ b/apps/smart-form/tests/keyboard-shortcuts-help.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for KeyboardShortcutsHelp component
+ *
+ * SPRINT-051-LAYER3-PHASE9-SMARTFORM-UX-POLISH
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { KeyboardShortcutsHelp } from '../app/submit-ticket/components/KeyboardShortcutsHelp';
+
+describe('KeyboardShortcutsHelp', () => {
+  it('renders the toggle button', () => {
+    render(<KeyboardShortcutsHelp />);
+    const btn = screen.getByRole('button', { name: /show keyboard shortcuts/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it('toggle button has aria-expanded=false initially', () => {
+    render(<KeyboardShortcutsHelp />);
+    const btn = screen.getByRole('button', { name: /show keyboard shortcuts/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('panel is not visible initially', () => {
+    render(<KeyboardShortcutsHelp />);
+    expect(screen.queryByRole('dialog', { name: /keyboard shortcuts/i })).not.toBeInTheDocument();
+  });
+
+  it('opens panel on button click', () => {
+    render(<KeyboardShortcutsHelp />);
+    const btn = screen.getByRole('button', { name: /show keyboard shortcuts/i });
+    fireEvent.click(btn);
+    expect(screen.getByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument();
+  });
+
+  it('toggle button has aria-expanded=true when open', () => {
+    render(<KeyboardShortcutsHelp />);
+    const btn = screen.getByRole('button', { name: /show keyboard shortcuts/i });
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('displays at least 5 shortcut entries when open', () => {
+    render(<KeyboardShortcutsHelp />);
+    fireEvent.click(screen.getByRole('button', { name: /show keyboard shortcuts/i }));
+    const items = screen.getAllByRole('listitem');
+    expect(items.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('shows Enter shortcut for adding a leg', () => {
+    render(<KeyboardShortcutsHelp />);
+    fireEvent.click(screen.getByRole('button', { name: /show keyboard shortcuts/i }));
+    expect(screen.getByText(/add current leg to bet slip/i)).toBeInTheDocument();
+  });
+
+  it('shows Esc shortcut for clearing form', () => {
+    render(<KeyboardShortcutsHelp />);
+    fireEvent.click(screen.getByRole('button', { name: /show keyboard shortcuts/i }));
+    expect(screen.getByText(/clear the current leg form/i)).toBeInTheDocument();
+  });
+
+  it('closes panel when close button is clicked', () => {
+    render(<KeyboardShortcutsHelp />);
+    fireEvent.click(screen.getByRole('button', { name: /show keyboard shortcuts/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Click the X button inside the panel (not the toggle button)
+    fireEvent.click(screen.getByRole('button', { name: /^close keyboard shortcuts$/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('toggle button label changes when open', () => {
+    render(<KeyboardShortcutsHelp />);
+    fireEvent.click(screen.getByRole('button', { name: /show keyboard shortcuts/i }));
+    expect(
+      screen.getByRole('button', { name: /close keyboard shortcuts help/i })
+    ).toBeInTheDocument();
+  });
+
+  it('panel has aria-controls pointing to panel id', () => {
+    render(<KeyboardShortcutsHelp />);
+    const btn = screen.getByRole('button', { name: /show keyboard shortcuts/i });
+    expect(btn).toHaveAttribute('aria-controls', 'keyboard-shortcuts-panel');
+  });
+});


### PR DESCRIPTION
## Summary

- **BetSlipPanel**: `aria-label` on Edit/Delete/Save/Cancel icon buttons; `htmlFor`+`id` on inline edit fields
- **GamePickForm**: `htmlFor`+`id` on all label-select/input pairs; `aria-required` on selection and odds
- **ManualEntryForm**: `role="alert"` + `aria-live="polite"` on ErrorBanner; `htmlFor`+`id` in `renderTeamField`; `role="status"` on loading state
- **KeyboardShortcutsHelp** (new): documents 5 existing shortcuts with toggle button, `aria-expanded`, `aria-controls`, dialog panel
- **SportsbookManualEntry**: KeyboardShortcutsHelp wired into header
- **Tests**: 11 new Jest tests for KeyboardShortcutsHelp (11/11 passing)

## Layer / Phase

Layer 3 / Phase 9 — SmartForm UX | Linear: [UNI-86](https://linear.app/unit-talk/issue/UNI-86)

## Verification

- Type-check: PASS (0 errors)
- Tests: 11/11 new tests passing
- Boundary: PASS — no `unified_picks` writes; `bridge_outbox` is only write target

## Test plan

- [x] `pnpm --filter unit-talk-smart-form type-check` → 0 errors
- [x] `jest tests/keyboard-shortcuts-help.test.tsx` → 11/11 pass
- [x] No `unified_picks` INSERT/UPDATE in smart-form source

🤖 Generated with [Claude Code](https://claude.com/claude-code)