### PR TITLE
feat(api): operator workflow registry — SPRINT-052

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -92,7 +92,8 @@
     "recap:daily": "tsx src/scripts/recap/generateRecap.ts --mode=daily",
     "recap:weekly": "tsx src/scripts/recap/generateRecap.ts --mode=weekly",
     "clean": "rimraf dist",
-    "ops:db:preflight": "tsx src/scripts/ops/supabase-migration-preflight.ts"
+    "ops:db:preflight": "tsx src/scripts/ops/supabase-migration-preflight.ts",
+    "ops:list": "tsx src/scripts/ops/list-workflows.ts"
   },
   "dependencies": {
     "@unit-talk/config": "workspace:*",

--- a/apps/api/src/api-server.ts
+++ b/apps/api/src/api-server.ts
@@ -14,6 +14,7 @@ import opsControlRouter from './routes/ops-control';
 import opsDiscordRoutingRouter from './routes/ops-discord-routing';
 import opsRecoveryRouter from './routes/ops-recovery';
 import opsStatusRouter from './routes/ops-status';
+import opsWorkflowsRouter from './routes/ops-workflows';
 import picksRouter from './routes/picks';
 import riskRouter from './routes/risk';
 import sloRouter from './routes/slo';
@@ -100,6 +101,8 @@ app.use('/ops', opsRouter);
 app.use('/ops', opsControlRouter);
 // SPRINT-044: Recovery & Replay endpoints (incident recovery via deterministic replay)
 app.use('/ops', opsRecoveryRouter);
+// SPRINT-052: Workflow registry discovery endpoint
+app.use('/ops', opsWorkflowsRouter);
 app.use('/version', versionRouter);
 app.use('/api/version', versionRouter);
 // RISK-ENGINE-FOUNDATION-001: Risk telemetry API

--- a/apps/api/src/lib/workflow-registry/__tests__/registry.test.ts
+++ b/apps/api/src/lib/workflow-registry/__tests__/registry.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for WorkflowRegistry
+ *
+ * SPRINT-052-LAYER3-PHASE11-OPERATOR-WORKFLOW-FOUNDATION
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  WORKFLOW_REGISTRY,
+  findWorkflow,
+  getAllWorkflows,
+  getCategories,
+  getCategoryCounts,
+  getWorkflowsByCategory,
+} from '../index';
+
+describe('WorkflowRegistry', () => {
+  describe('getAllWorkflows()', () => {
+    it('returns all registered workflows', () => {
+      const workflows = getAllWorkflows();
+      expect(workflows.length).toBeGreaterThanOrEqual(10);
+    });
+
+    it('returns an array of workflow entries', () => {
+      const workflows = getAllWorkflows();
+      for (const w of workflows) {
+        expect(w.name).toBeTruthy();
+        expect(w.description).toBeTruthy();
+        expect(w.category).toBeTruthy();
+        expect(w.scriptPath).toBeTruthy();
+        expect(w.invocation).toBeTruthy();
+        expect(['low', 'medium', 'high']).toContain(w.riskLevel);
+      }
+    });
+
+    it('has no duplicate workflow names', () => {
+      const names = getAllWorkflows().map(w => w.name);
+      const unique = new Set(names);
+      expect(unique.size).toBe(names.length);
+    });
+  });
+
+  describe('getWorkflowsByCategory()', () => {
+    it('returns only workflows in the specified category', () => {
+      const analysis = getWorkflowsByCategory('analysis');
+      expect(analysis.length).toBeGreaterThanOrEqual(1);
+      for (const w of analysis) {
+        expect(w.category).toBe('analysis');
+      }
+    });
+
+    it('returns backfill workflows', () => {
+      const backfill = getWorkflowsByCategory('backfill');
+      expect(backfill.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('returns health workflows', () => {
+      const health = getWorkflowsByCategory('health');
+      expect(health.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('returns empty array for unknown category', () => {
+      const result = getWorkflowsByCategory('nonexistent' as never);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findWorkflow()', () => {
+    it('finds a workflow by name', () => {
+      const workflow = findWorkflow('simple-health-check');
+      expect(workflow).toBeDefined();
+      expect(workflow?.name).toBe('simple-health-check');
+      expect(workflow?.category).toBe('health');
+    });
+
+    it('returns undefined for unknown name', () => {
+      const result = findWorkflow('does-not-exist');
+      expect(result).toBeUndefined();
+    });
+
+    it('finds backfill-promotion-band-null', () => {
+      const w = findWorkflow('backfill-promotion-band-null');
+      expect(w).toBeDefined();
+      expect(w?.riskLevel).toBe('medium');
+    });
+  });
+
+  describe('getCategories()', () => {
+    it('returns an array of unique categories', () => {
+      const categories = getCategories();
+      expect(categories.length).toBeGreaterThanOrEqual(4);
+      const unique = new Set(categories);
+      expect(unique.size).toBe(categories.length);
+    });
+
+    it('includes all expected categories', () => {
+      const categories = getCategories();
+      expect(categories).toContain('analysis');
+      expect(categories).toContain('backfill');
+      expect(categories).toContain('health');
+    });
+
+    it('returns categories in sorted order', () => {
+      const categories = getCategories();
+      const sorted = [...categories].sort();
+      expect(categories).toEqual(sorted);
+    });
+  });
+
+  describe('getCategoryCounts()', () => {
+    it('returns counts for each category', () => {
+      const counts = getCategoryCounts();
+      const categories = getCategories();
+      for (const cat of categories) {
+        expect(counts[cat]).toBeGreaterThanOrEqual(1);
+      }
+    });
+
+    it('total count matches registry size', () => {
+      const counts = getCategoryCounts();
+      const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
+      expect(total).toBe(WORKFLOW_REGISTRY.length);
+    });
+  });
+
+  describe('WORKFLOW_REGISTRY schema', () => {
+    it('all high-risk workflows have descriptive names', () => {
+      const highRisk = WORKFLOW_REGISTRY.filter(w => w.riskLevel === 'high');
+      for (const w of highRisk) {
+        expect(w.description.length).toBeGreaterThan(20);
+      }
+    });
+
+    it('all workflows with required parameters document them', () => {
+      const withParams = WORKFLOW_REGISTRY.filter(
+        w => w.parameters && w.parameters.some(p => p.required)
+      );
+      for (const w of withParams) {
+        expect(w.parameters!.length).toBeGreaterThan(0);
+        for (const p of w.parameters!) {
+          expect(p.name).toBeTruthy();
+          expect(p.description).toBeTruthy();
+        }
+      }
+    });
+  });
+});

--- a/apps/api/src/lib/workflow-registry/index.ts
+++ b/apps/api/src/lib/workflow-registry/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Workflow Registry — Public API
+ *
+ * SPRINT-052-LAYER3-PHASE11-OPERATOR-WORKFLOW-FOUNDATION
+ */
+
+export type {
+  WorkflowCategory,
+  WorkflowEntry,
+  WorkflowParameter,
+  WorkflowRiskLevel,
+} from './types';
+export { WORKFLOW_REGISTRY } from './registry';
+
+import { WORKFLOW_REGISTRY } from './registry';
+
+import type { WorkflowCategory, WorkflowEntry } from './types';
+
+/** Return all registered workflows */
+export function getAllWorkflows(): WorkflowEntry[] {
+  return WORKFLOW_REGISTRY;
+}
+
+/** Return workflows filtered by category */
+export function getWorkflowsByCategory(category: WorkflowCategory): WorkflowEntry[] {
+  return WORKFLOW_REGISTRY.filter(w => w.category === category);
+}
+
+/** Look up a single workflow by name */
+export function findWorkflow(name: string): WorkflowEntry | undefined {
+  return WORKFLOW_REGISTRY.find(w => w.name === name);
+}
+
+/** Return unique categories present in the registry */
+export function getCategories(): WorkflowCategory[] {
+  return [...new Set(WORKFLOW_REGISTRY.map(w => w.category))].sort() as WorkflowCategory[];
+}
+
+/** Return count of workflows per category */
+export function getCategoryCounts(): Record<WorkflowCategory, number> {
+  const counts: Partial<Record<WorkflowCategory, number>> = {};
+  for (const w of WORKFLOW_REGISTRY) {
+    counts[w.category] = (counts[w.category] ?? 0) + 1;
+  }
+  return counts as Record<WorkflowCategory, number>;
+}

--- a/apps/api/src/lib/workflow-registry/registry.ts
+++ b/apps/api/src/lib/workflow-registry/registry.ts
@@ -1,0 +1,263 @@
+/**
+ * Workflow Registry — Curated Catalog
+ *
+ * SPRINT-052-LAYER3-PHASE11-OPERATOR-WORKFLOW-FOUNDATION
+ *
+ * Statically registered workflows with metadata. Covers the 5 canonical
+ * operator script categories: analysis, backfill, feed, health, settlement.
+ */
+
+import type { WorkflowEntry } from './types';
+
+export const WORKFLOW_REGISTRY: WorkflowEntry[] = [
+  // ── ANALYSIS ──────────────────────────────────────────────────────────────
+  {
+    name: 'analyze-grading-promotion',
+    displayName: 'Analyze Grading & Promotion',
+    description:
+      'Analyze grading pipeline performance and promotion band distribution across recent picks.',
+    category: 'analysis',
+    scriptPath: 'analyze-grading-promotion.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/analyze-grading-promotion.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'edge-validation-report',
+    displayName: 'Edge Validation Report',
+    description:
+      'Generate CLV edge validation report comparing pre/post line movement for recent picks.',
+    category: 'analysis',
+    scriptPath: 'edge-validation-report.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/edge-validation-report.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'verify-slo',
+    displayName: 'Verify SLO Attainment',
+    description:
+      'Verify SLO attainment against the 4 platform SLOs: lifecycle, Discord posting, grading latency, settlement accuracy.',
+    category: 'analysis',
+    scriptPath: 'verify-slo.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/verify-slo.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'check-grading-status',
+    displayName: 'Check Grading Status',
+    description:
+      'Check current grading status: pending picks, scoring distribution, recent grade activity.',
+    category: 'analysis',
+    scriptPath: 'check-grading-status.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/check-grading-status.ts',
+    requiresDatabase: true,
+  },
+
+  // ── BACKFILL ──────────────────────────────────────────────────────────────
+  {
+    name: 'backfill-promotion-band-null',
+    displayName: 'Backfill Null Promotion Bands',
+    description:
+      'Backfill picks with null promotion_band that passed meetsPromotionCriteria(). Sets band to HARD via operator_override lifecycle role.',
+    category: 'backfill',
+    scriptPath: 'backfill-promotion-band-null.ts',
+    riskLevel: 'medium',
+    invocation: 'pnpm --filter api tsx src/scripts/backfill-promotion-band-null.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'backfill-market-props-batch',
+    displayName: 'Backfill Market Props (Batch)',
+    description:
+      'Batch backfill market prop data for provider_offers. Processes in configurable batch sizes.',
+    category: 'backfill',
+    scriptPath: 'backfill-market-props-batch.ts',
+    riskLevel: 'medium',
+    invocation: 'pnpm --filter api tsx src/scripts/backfill-market-props-batch.ts',
+    requiresDatabase: true,
+    parameters: [
+      {
+        name: '--batch-size',
+        description: 'Number of records per batch (default: 100)',
+        required: false,
+        type: 'number',
+        example: '--batch-size 50',
+      },
+    ],
+  },
+  {
+    name: 'backfill-feature-contributions',
+    displayName: 'Backfill Feature Contributions',
+    description:
+      'Backfill ML feature contribution scores for picks missing them. Required for CLV attribution.',
+    category: 'backfill',
+    scriptPath: 'backfill-feature-contributions.ts',
+    riskLevel: 'medium',
+    invocation: 'pnpm --filter api tsx src/scripts/backfill-feature-contributions.ts',
+    requiresDatabase: true,
+  },
+
+  // ── FEED ──────────────────────────────────────────────────────────────────
+  {
+    name: 'feed-agent-backfill',
+    displayName: 'Feed Agent Backfill',
+    description:
+      'Trigger FeedAgent to backfill missed provider_offers from external feeds (SGO + OddsAPI).',
+    category: 'feed',
+    scriptPath: 'feed-agent-backfill.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/feed-agent-backfill.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'run-shadow',
+    displayName: 'Run Shadow Mode Comparison',
+    description:
+      'Run shadow mode comparison between V1 and V3 grading paths. Outputs divergence report.',
+    category: 'feed',
+    scriptPath: 'run-shadow.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/run-shadow.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'run-replay',
+    displayName: 'Run Deterministic Replay',
+    description:
+      'Execute deterministic replay from a production event journal file. Writes proof bundle to out/replay-runs/.',
+    category: 'feed',
+    scriptPath: 'run-replay.ts',
+    riskLevel: 'low',
+    invocation:
+      'pnpm --filter api tsx src/scripts/run-replay.ts --journal <path> --from <ISO> --to <ISO>',
+    requiresDatabase: false,
+    parameters: [
+      {
+        name: '--journal',
+        description: 'Path to the JSONL journal file',
+        required: true,
+        type: 'string',
+        example: '--journal out/journals/2026-03-15.jsonl',
+      },
+      {
+        name: '--from',
+        description: 'Replay window start (ISO 8601)',
+        required: true,
+        type: 'string',
+        example: '--from 2026-03-15T00:00:00Z',
+      },
+      {
+        name: '--to',
+        description: 'Replay window end (ISO 8601)',
+        required: true,
+        type: 'string',
+        example: '--to 2026-03-15T23:59:59Z',
+      },
+    ],
+  },
+
+  // ── HEALTH ────────────────────────────────────────────────────────────────
+  {
+    name: 'simple-health-check',
+    displayName: 'Simple Health Check',
+    description:
+      'Quick platform health check: Supabase connectivity, agent_health table, outbox depth.',
+    category: 'health',
+    scriptPath: 'simple-health-check.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/simple-health-check.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'verify-gates',
+    displayName: 'Verify All Gates',
+    description:
+      'Run all verification gates: lifecycle single-writer, type-check, SLO status, single-writer gate.',
+    category: 'health',
+    scriptPath: 'verify-gates.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/verify-gates.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'system-health-validator',
+    displayName: 'System Health Validator',
+    description:
+      'Full system health validation: all agents, outbox, workers, database connectivity, recent pick throughput.',
+    category: 'health',
+    scriptPath: 'system-health-validator.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/system-health-validator.ts',
+    requiresDatabase: true,
+  },
+
+  // ── SETTLEMENT ────────────────────────────────────────────────────────────
+  {
+    name: 'diagnose-grading-system',
+    displayName: 'Diagnose Grading System',
+    description:
+      'Full grading system diagnosis: NaN checks, scoring integrity, pick state distribution, promotion pipeline health.',
+    category: 'settlement',
+    scriptPath: 'diagnose-grading-system.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/diagnose-grading-system.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'check-parlay-status',
+    displayName: 'Check Parlay Status',
+    description:
+      'Check parlay grouping status: pending parlays, settlement state, leg completion counts.',
+    category: 'settlement',
+    scriptPath: 'check-parlay-status.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm --filter api tsx src/scripts/check-parlay-status.ts',
+    requiresDatabase: true,
+  },
+
+  // ── OPS ───────────────────────────────────────────────────────────────────
+  {
+    name: 'db-preflight',
+    displayName: 'Database Migration Preflight',
+    description: 'Run database migration preflight checks before applying new migrations.',
+    category: 'ops',
+    scriptPath: 'ops/supabase-migration-preflight.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm ops:db:preflight',
+    requiresDatabase: true,
+  },
+  {
+    name: 'start-all-workflows',
+    displayName: 'Start All Temporal Workflows',
+    description:
+      'Start all registered Temporal workflows: feed ingestion, recap generation, analytics.',
+    category: 'ops',
+    scriptPath: 'start-all-workflows.ts',
+    riskLevel: 'high',
+    invocation: 'pnpm --filter api tsx src/scripts/start-all-workflows.ts',
+    requiresDatabase: true,
+  },
+  {
+    name: 'run-strategy',
+    displayName: 'Run Strategy Simulation',
+    description:
+      'Execute strategy evaluation simulation comparing flat-unit, kelly, and custom staking strategies.',
+    category: 'ops',
+    scriptPath: 'run-strategy.ts',
+    riskLevel: 'low',
+    invocation: 'pnpm strategy:simulate',
+    requiresDatabase: false,
+    parameters: [
+      {
+        name: '--strategy',
+        description: 'Strategy ID to simulate (flat-unit, kelly-025, kelly-010)',
+        required: false,
+        type: 'string',
+        example: '--strategy kelly-025',
+      },
+    ],
+  },
+];

--- a/apps/api/src/lib/workflow-registry/types.ts
+++ b/apps/api/src/lib/workflow-registry/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Workflow Registry Types
+ *
+ * SPRINT-052-LAYER3-PHASE11-OPERATOR-WORKFLOW-FOUNDATION
+ */
+
+export type WorkflowCategory = 'analysis' | 'backfill' | 'feed' | 'health' | 'settlement' | 'ops';
+
+export type WorkflowRiskLevel = 'low' | 'medium' | 'high';
+
+export interface WorkflowParameter {
+  name: string;
+  description: string;
+  required: boolean;
+  type: 'string' | 'number' | 'boolean';
+  example?: string;
+}
+
+export interface WorkflowEntry {
+  /** Unique identifier (kebab-case) */
+  name: string;
+  /** Human-readable display name */
+  displayName: string;
+  /** What this workflow does */
+  description: string;
+  /** Category for grouping */
+  category: WorkflowCategory;
+  /** Relative path from apps/api/src/scripts/ */
+  scriptPath: string;
+  /** Risk level — affects whether confirmation is required */
+  riskLevel: WorkflowRiskLevel;
+  /** CLI invocation example */
+  invocation: string;
+  /** Optional parameter definitions */
+  parameters?: WorkflowParameter[];
+  /** Requires live Supabase connection */
+  requiresDatabase?: boolean;
+}

--- a/apps/api/src/routes/ops-workflows.ts
+++ b/apps/api/src/routes/ops-workflows.ts
@@ -1,0 +1,97 @@
+/**
+ * Operator Workflow Discovery Routes
+ *
+ * SPRINT-052-LAYER3-PHASE11-OPERATOR-WORKFLOW-FOUNDATION
+ * Layer/Phase: Layer 3 / Phase 11 — Workflow Optimization
+ *
+ * GET /ops/workflows          → list all registered workflows (optional ?category= filter)
+ * GET /ops/workflows/:name    → get a single workflow by name
+ *
+ * Auth: operatorAuth (JWT)
+ * Audit: operatorAuditLog (read operations logged for traceability)
+ */
+
+import { type IRouter, Router } from 'express';
+
+import {
+  findWorkflow,
+  getAllWorkflows,
+  getCategories,
+  getCategoryCounts,
+  getWorkflowsByCategory,
+} from '../lib/workflow-registry';
+import { operatorAuditLog } from '../middleware/operatorAuditLog';
+import { operatorAuth } from '../middleware/operatorAuth';
+import { createLogger } from '../utils/logger';
+
+import type { WorkflowCategory } from '../lib/workflow-registry';
+
+const router: IRouter = Router();
+const logger = createLogger('ops-workflows');
+
+// Auth + audit for all workflow routes
+router.use('/workflows', operatorAuth, operatorAuditLog);
+
+/**
+ * GET /ops/workflows
+ * Returns the workflow registry, optionally filtered by category.
+ *
+ * Query params:
+ *   category — filter by category (analysis | backfill | feed | health | settlement | ops)
+ */
+router.get('/workflows', (req, res) => {
+  try {
+    const { category } = req.query;
+
+    const workflows =
+      category && typeof category === 'string'
+        ? getWorkflowsByCategory(category as WorkflowCategory)
+        : getAllWorkflows();
+
+    const categories = getCategories();
+    const counts = getCategoryCounts();
+
+    logger.info('Workflow registry queried', {
+      filter: category ?? 'all',
+      returned: workflows.length,
+    });
+
+    return res.json({
+      workflows,
+      meta: {
+        total: getAllWorkflows().length,
+        returned: workflows.length,
+        categories,
+        categoryCounts: counts,
+      },
+    });
+  } catch (err) {
+    logger.error('Failed to list workflows', { error: err });
+    return res.status(500).json({ error: 'Failed to retrieve workflow registry' });
+  }
+});
+
+/**
+ * GET /ops/workflows/:name
+ * Returns a single workflow entry by name.
+ */
+router.get('/workflows/:name', (req, res) => {
+  try {
+    const { name } = req.params;
+    const workflow = findWorkflow(name);
+
+    if (!workflow) {
+      return res.status(404).json({
+        error: `Workflow '${name}' not found`,
+        availableNames: getAllWorkflows().map(w => w.name),
+      });
+    }
+
+    return res.json({ workflow });
+  } catch (err) {
+    logger.error('Failed to get workflow', { name: req.params.name, error: err });
+    return res.status(500).json({ error: 'Failed to retrieve workflow' });
+  }
+});
+
+export default router;

--- a/apps/api/src/scripts/ops/list-workflows.ts
+++ b/apps/api/src/scripts/ops/list-workflows.ts
@@ -1,0 +1,88 @@
+/**
+ * ops:list — Workflow Discovery CLI
+ *
+ * SPRINT-052-LAYER3-PHASE11-OPERATOR-WORKFLOW-FOUNDATION
+ *
+ * Usage:
+ *   pnpm ops:list
+ *   pnpm ops:list --category analysis
+ *   pnpm ops:list --category health
+ */
+
+import {
+  getAllWorkflows,
+  getCategories,
+  getCategoryCounts,
+  getWorkflowsByCategory,
+} from '../../lib/workflow-registry';
+import type { WorkflowCategory } from '../../lib/workflow-registry';
+
+const RISK_COLOR: Record<string, string> = {
+  low: '\x1b[32m', // green
+  medium: '\x1b[33m', // yellow
+  high: '\x1b[31m', // red
+};
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+
+function riskLabel(level: string): string {
+  return `${RISK_COLOR[level] ?? ''}${level.toUpperCase()}${RESET}`;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const categoryIdx = args.indexOf('--category');
+  const requestedCategory = categoryIdx !== -1 ? args[categoryIdx + 1] : undefined;
+
+  const allWorkflows = getAllWorkflows();
+  const categories = getCategories();
+  const counts = getCategoryCounts();
+
+  if (requestedCategory) {
+    const workflows = getWorkflowsByCategory(requestedCategory as WorkflowCategory);
+    if (workflows.length === 0) {
+      console.error(`No workflows found for category: ${requestedCategory}`);
+      console.error(`Available categories: ${categories.join(', ')}`);
+      process.exit(1);
+    }
+
+    console.log(`\n${BOLD}Workflows — Category: ${requestedCategory}${RESET}\n`);
+    for (const w of workflows) {
+      console.log(`  ${BOLD}${w.name}${RESET} [${riskLabel(w.riskLevel)}]`);
+      console.log(`  ${DIM}${w.description}${RESET}`);
+      console.log(`  ${DIM}$ ${w.invocation}${RESET}`);
+      if (w.parameters && w.parameters.length > 0) {
+        for (const p of w.parameters) {
+          console.log(`    ${p.required ? '*' : ' '} ${p.name}: ${p.description}`);
+        }
+      }
+      console.log();
+    }
+    console.log(`  Total: ${workflows.length} workflow(s) in '${requestedCategory}'\n`);
+    return;
+  }
+
+  // Show all workflows grouped by category
+  console.log(`\n${BOLD}Unit Talk — Operator Workflow Registry${RESET}`);
+  console.log(
+    `${DIM}${allWorkflows.length} workflows across ${categories.length} categories${RESET}\n`
+  );
+
+  for (const category of categories) {
+    const workflows = getWorkflowsByCategory(category);
+    console.log(`${BOLD}${category.toUpperCase()} (${counts[category]})${RESET}`);
+    for (const w of workflows) {
+      console.log(
+        `  ${w.name.padEnd(36)} [${riskLabel(w.riskLevel).padEnd(12)}]  ${DIM}${w.description.slice(0, 70)}${w.description.length > 70 ? '…' : ''}${RESET}`
+      );
+    }
+    console.log();
+  }
+
+  console.log(
+    `${DIM}Run 'pnpm ops:list --category <name>' for full details and parameters.${RESET}\n`
+  );
+}
+
+main();


### PR DESCRIPTION
## SPRINT-052-LAYER3-PHASE11-OPERATOR-WORKFLOW-FOUNDATION

**Layer / Phase**: Layer 3 / Phase 11 — Workflow Optimization

## Summary

- **WorkflowRegistry module** (`apps/api/src/lib/workflow-registry/`) — 18 curated workflow entries across 6 categories (analysis, backfill, feed, health, settlement, ops) with typed metadata (riskLevel, parameters, invocation, scriptPath)
- **GET /ops/workflows** — list all registered workflows with optional `?category=` filter; returns workflows + meta (total, counts per category)
- **GET /ops/workflows/:name** — fetch a single workflow by name; 404 with available names on miss
- **`pnpm ops:list` CLI** — terminal-friendly workflow discovery with color-coded risk levels and `--category` flag
- Both HTTP endpoints gated by `operatorAuth` (JWT) + `operatorAuditLog`
- 17 vitest tests; full suite 995/995 passing
- Type-check: 0 errors

## Pre-existing CI Failures (inherited)
- Quality Assurance Gate — observability build (pre-existing)
- Quarantine Enforcement Gate (pre-existing)
- Smart Form V1.1 Compliance Gates (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)