### PR TITLE
chore(governance): closeout SPRINT-053-GOVERNANCE-NAMING-CONVENTION

### DIFF
--- a/governance/closeouts/SPRINT-053-GOVERNANCE-NAMING-CONVENTION.md
+++ b/governance/closeouts/SPRINT-053-GOVERNANCE-NAMING-CONVENTION.md
@@ -1,0 +1,34 @@
+# Sprint Closeout — SPRINT-053-GOVERNANCE-NAMING-CONVENTION
+
+**Sprint**: SPRINT-053-GOVERNANCE-NAMING-CONVENTION **Phase**: Meta (Governance)
+**Date**: 2026-03-15 **Status**: COMPLETE **PR**: #234 — merged at 4789cabd
+**Linear**: UNI-88 **Resolves**: DRIFT-H2
+
+## Objective
+
+Establish and document the canonical sprint naming convention, update
+enforcement tooling, and resolve DRIFT-H2 (sprint naming inconsistency).
+
+## Deliverables
+
+- `docs/claude/SPRINT_NAMING_CONVENTION.md` (new) — canonical naming authority:
+  Pattern A (`SPRINT-NNN-DESCRIPTIVE`) for sequenced sprints; Pattern B
+  (`SPRINT-DOMAIN-DESCRIPTOR`) for governance/Claude OS sprints; validation
+  rules; deprecated pattern table; legacy tag mapping (SPRINT-021–052);
+  governance tag flow reference
+- `CLAUDE.md §6` — updated sprint naming from stale `SPRINT-<NAME>-###` (number
+  at end) to reference canonical doc with both patterns
+- `tools/governance/sprint-gate.js` — reads from `NEXT_5_SPRINTS.md` (Sprint 1
+  line, primary authority) + `INTELLIGENCE_PIPELINE_SPRINT_ORDER.md` (legacy
+  fallback for SPRINT-031–040); format validation added
+- `docs/status/DRIFT_REPORT.md` — DRIFT-H2 moved to resolved; 0 HIGH items
+  active; summary table updated (5 active, 13 resolved)
+
+## Verification
+
+- Sprint gate: `node tools/governance/sprint-gate.js` → reads NEXT_5_SPRINTS.md
+- Sprint gate: valid sprint name → PASS
+- Sprint gate: wrong sprint → FAIL with correct message
+- Sprint gate: invalid format → FAIL with format guidance
+- Type-check: 0 errors (docs + JS only)
+- No TypeScript or runtime changes


### PR DESCRIPTION
Governance closeout to trigger tag minting via mint-governed-tag.yml.