### PR TITLE
feat(skills): add observability skills powered by MCP layer — SPRINT-056

### DIFF
--- a/.claude/skills/edge-check.md
+++ b/.claude/skills/edge-check.md
@@ -1,0 +1,205 @@
+# Skill: Edge Check
+
+## Purpose
+
+Run quick directional edge and calibration checks on a set of market prices or
+model predictions. Use this to validate whether a pick has positive CLV at time
+of bet, or whether the scoring model is drifting from calibration.
+
+## When to Use
+
+- Before posting a manually-sourced pick: verify the book odds show positive
+  edge
+- After a losing streak: check if model calibration has drifted
+- Reviewing a set of picks from a specific market type for CLV pattern
+- Directional check on whether closing line confirms or denies the opening edge
+- Routine calibration audit (weekly or after > 50 new settled picks)
+
+## Invocation
+
+```
+/edge-check clv --odds <book1_odds> <book2_odds> [--closing <closing_odds>]
+/edge-check calibration --data <predictions_json>
+```
+
+Or invoked conversationally: "Check the edge on DraftKings -110, FanDuel -108,
+BetMGM -112."
+
+## Procedure
+
+### Part A: CLV Edge Check
+
+#### Step 1: Gather Book Offers
+
+Collect 2+ American odds values from different books for the **same side** of
+the market. More books = more reliable consensus.
+
+Example: DraftKings -110, FanDuel -108, BetMGM -112
+
+#### Step 2: Compute CLV
+
+Call `compute_clv` (unit-talk-intelligence):
+
+```
+Tool: compute_clv
+Input: {
+  "book_offers": [
+    { "odds": -110, "book_profile": "retail" },
+    { "odds": -108, "book_profile": "retail" },
+    { "odds": -112, "book_profile": "retail" }
+  ],
+  "devig_method": "proportional",
+  "closing_odds": -106
+}
+```
+
+**Input fields:**
+
+| Field                          | Required | Notes                                             |
+| ------------------------------ | -------- | ------------------------------------------------- |
+| `book_offers[].odds`           | YES      | American odds per book (≥2 books)                 |
+| `book_offers[].book_profile`   | no       | `retail` \| `market_maker` \| `sharp`             |
+| `book_offers[].liquidity_tier` | no       | `low` \| `medium` \| `high`                       |
+| `book_offers[].data_quality`   | no       | `good` \| `partial` \| `suspect`                  |
+| `devig_method`                 | no       | `proportional` (default), `shin`, `power`         |
+| `closing_odds`                 | no       | Closing line American odds — enables CLV estimate |
+
+**Output fields:**
+
+| Field                 | Meaning                                                             |
+| --------------------- | ------------------------------------------------------------------- |
+| `consensus_fair_prob` | Devigged consensus probability (0.0–1.0)                            |
+| `consensus_fair_odds` | Fair American odds                                                  |
+| `edge_pct`            | EV as % of stake (positive = +EV bet)                               |
+| `edge_positive`       | Boolean: `true` if bet has positive expected value                  |
+| `clv_estimate`        | CLV in probability points vs closing line (null if no closing_odds) |
+| `model_version`       | `inline-<method>`                                                   |
+
+**Math drift warning**: This tool uses a 2% vig approximation (one-sided odds
+input). For standard juice (-105 to -115) the approximation is accurate within
+~0.5%. For heavily juiced lines or alternate markets, treat as directional only.
+See `packages/mcp-intelligence/src/adapters/index.ts` for the documented drift.
+
+#### Step 3: Interpret CLV Result
+
+| Condition              | Interpretation                                   |
+| ---------------------- | ------------------------------------------------ |
+| `edge_pct > 3.0`       | Strong positive edge — above noise threshold     |
+| `1.0 < edge_pct ≤ 3.0` | Modest edge — consistent with the model          |
+| `edge_pct ≤ 0`         | No edge at open; closing line will determine CLV |
+| `clv_estimate > 0`     | Beat the close — confirms positive CLV           |
+| `clv_estimate < 0`     | Negative CLV — closing line moved against us     |
+
+### Part B: Calibration Check
+
+#### Step 1: Prepare Prediction Data
+
+Gather settled picks with their model predicted probability and actual outcome:
+
+```json
+[
+  { "predicted_prob": 0.62, "actual_outcome": 1 },
+  { "predicted_prob": 0.55, "actual_outcome": 0 },
+  ...
+]
+```
+
+Minimum: 10 predictions. Meaningful signal requires ≥ 50. `actual_outcome`: 1 =
+win, 0 = loss, 0.5 = push.
+
+#### Step 2: Compute Calibration
+
+Call `compute_calibration` (unit-talk-intelligence):
+
+```
+Tool: compute_calibration
+Input: {
+  "predictions": [ ... ],
+  "bucket_width": 0.1
+}
+```
+
+**Output fields:**
+
+| Field           | Meaning                                                           |
+| --------------- | ----------------------------------------------------------------- |
+| `brier_score`   | Mean squared error of predictions (lower = better; random = 0.25) |
+| `log_loss`      | Log loss (lower = better)                                         |
+| `ece`           | Expected Calibration Error (0 = perfect; < 0.05 = good)           |
+| `mce`           | Maximum Calibration Error (worst bucket deviation)                |
+| `n_predictions` | Sample count                                                      |
+| `status`        | `CALIBRATED` \| `DRIFT` \| `MISCALIBRATED`                        |
+
+**Status thresholds:**
+
+| Status          | ECE    | Brier  |
+| --------------- | ------ | ------ |
+| `CALIBRATED`    | < 0.05 | < 0.25 |
+| `DRIFT`         | < 0.10 | < 0.30 |
+| `MISCALIBRATED` | ≥ 0.10 | ≥ 0.30 |
+
+### Step 3: Report
+
+```markdown
+## Edge Check — <computed_at>
+
+### CLV Analysis
+
+Books: <book1> <odds1>, <book2> <odds2>, ... Devig method: proportional
+
+| Metric           | Value                 |
+| ---------------- | --------------------- | ----- |
+| Fair probability | X.X%                  |
+| Fair odds        | <american>            |
+| Edge (EV %)      | +X.X%                 | -X.X% |
+| Edge positive    | yes / no              |
+| CLV estimate     | +X.Xpp / -X.Xpp / N/A |
+
+**Verdict**: ✅ Positive edge | ⚠️ Near-zero | ❌ Negative EV
+
+### Calibration Analysis (N=<n_predictions>)
+
+| Metric      | Value | Threshold | Status   |
+| ----------- | ----- | --------- | -------- |
+| Brier score | X.XXX | < 0.25    | ✅/⚠️/❌ |
+| ECE         | X.XXX | < 0.05    | ✅/⚠️/❌ |
+| MCE         | X.XXX | —         | —        |
+| Log loss    | X.XXX | —         | —        |
+
+**Status**: CALIBRATED | DRIFT | MISCALIBRATED
+
+### Recommendation
+
+<one-line recommendation based on edge + calibration state>
+```
+
+## Escalation Paths
+
+| Finding                                             | Recommended Action                                              |
+| --------------------------------------------------- | --------------------------------------------------------------- |
+| `edge_pct > 0` + `clv_estimate > 0`                 | Model confirmed positive; proceed                               |
+| `edge_pct > 0` + `clv_estimate < -2`                | Edge eroded at close; investigate market movement               |
+| `status = DRIFT`                                    | Monitor for 2 more weeks; do not adjust model weights yet       |
+| `status = MISCALIBRATED`                            | File investigation sprint; check shadow_scoring_runs divergence |
+| `clv_estimate` consistently negative over 20+ picks | Market timing or line shopping issue                            |
+
+For MISCALIBRATED: run `get_shadow_divergence` via unit-talk-intelligence to
+check if shadow scoring is diverging from production.
+
+## Relevant Repo Paths
+
+| Path                                              | Role                                                     |
+| ------------------------------------------------- | -------------------------------------------------------- |
+| `packages/mcp-intelligence/src/tools/index.ts`    | `compute_clv`, `compute_calibration`                     |
+| `packages/mcp-intelligence/src/adapters/index.ts` | Inline math; math drift documented                       |
+| `apps/api/src/lib/probability/devigConsensus.ts`  | Canonical devig (2-sided, weighted)                      |
+| `apps/api/src/lib/verification/`                  | R3 shadow mode, R5 strategy simulation                   |
+| `docs/ops/SLO_DEFINITIONS.md`                     | Grading latency SLO that may indicate calibration issues |
+
+## Expected Output
+
+- Fair probability and American odds from book consensus
+- EV% and CLV estimate (if closing odds provided)
+- Calibration metrics: Brier, ECE, MCE, log_loss
+- Status: CALIBRATED / DRIFT / MISCALIBRATED
+- One-line recommendation

--- a/.claude/skills/pick-trace.md
+++ b/.claude/skills/pick-trace.md
@@ -1,0 +1,192 @@
+# Skill: Pick Trace
+
+## Purpose
+
+Trace a single pick through its full lifecycle: current stage, all lifecycle
+fields, and settlement records. Answers "why hasn't this pick been
+posted/settled yet?" without needing direct database access.
+
+## When to Use
+
+- A specific pick UUID is suspected stuck or incorrectly staged
+- Discord pick is not appearing for a known bet_slip_id
+- Settlement result disputes — verify what was recorded
+- Debugging BLOCKED or FAILED picks to read the reason
+- Verifying a pick's lifecycle after manual operator intervention
+
+## Invocation
+
+```
+/pick-trace <pick-uuid>
+```
+
+Requires one argument: the pick UUID (from `unified_picks.id`).
+
+If you only have a `bet_slip_id`, run `query_picks` first to resolve the UUID:
+
+```
+Tool: query_picks
+Input: { "status": "<any>", "limit": 10 }
+```
+
+Then filter the result by `bet_slip_id` to get the `id`.
+
+## Procedure
+
+### Step 1: Full Pick Detail
+
+Call `get_pick` (unit-talk-state):
+
+```
+Tool: get_pick
+Input: { "id": "<pick-uuid>" }
+```
+
+Returns `null` if the pick does not exist. Check `id` validity if null.
+
+Key fields:
+
+| Field                 | Meaning                                            |
+| --------------------- | -------------------------------------------------- |
+| `derived_stage`       | Canonical computed stage (see stage table below)   |
+| `status`              | Raw status column                                  |
+| `promotion_status`    | `pending` \| `queued` \| `approved` \| `rejected`  |
+| `promotion_band`      | `HARD` \| `STRONG` \| `MEDIUM` \| `LIGHT` \| null  |
+| `posted_to_discord`   | Whether Discord post was confirmed                 |
+| `discord_message_id`  | Discord message ID (null = not posted)             |
+| `settlement_status`   | `pending` \| `settled` \| `void` \| `disputed`     |
+| `settlement_result`   | `win` \| `loss` \| `push` \| null                  |
+| `settlement_frozen`   | If true, settlement is locked                      |
+| `blocked_reason`      | Non-null = pick is BLOCKED; contains reason string |
+| `failed_reason`       | Non-null = pick is FAILED; contains reason string  |
+| `created_at`          | Pick creation time                                 |
+| `placed_at`           | When bet was placed                                |
+| `promotion_queued_at` | When pick entered promotion queue                  |
+| `promotion_posted_at` | When pick was promoted to final                    |
+| `settled_at`          | When settlement was recorded                       |
+
+**Canonical stage derivation** (matches `deriveLifecycleStage` exactly):
+
+| `derived_stage` | Condition                                                       |
+| --------------- | --------------------------------------------------------------- |
+| `CANCELLED`     | `status === 'cancelled'`                                        |
+| `VOID`          | `settlement_status === 'void'`                                  |
+| `DISPUTED`      | `settlement_status === 'disputed'`                              |
+| `SETTLED`       | `settlement_status === 'settled'`                               |
+| `BLOCKED`       | `blocked_reason` is non-null                                    |
+| `FAILED`        | `failed_reason` is non-null                                     |
+| `POSTED`        | `posted_to_discord = true` AND `discord_message_id` is non-null |
+| `QUEUED`        | `promotion_status === 'queued'`                                 |
+| `SUBMITTED`     | Everything else (default)                                       |
+
+### Step 2: Lifecycle Stage (lightweight confirm)
+
+Call `get_lifecycle_stage` (unit-talk-state):
+
+```
+Tool: get_lifecycle_stage
+Input: { "id": "<pick-uuid>" }
+```
+
+Use this to confirm `derived_stage` without the full pick payload. Cross-check:
+if `get_pick.derived_stage` ≠ `get_lifecycle_stage.derived_stage`, report the
+discrepancy (should never happen — same derivation logic).
+
+Key extra fields vs `get_pick`:
+
+- Both return `promotion_queued_at` and `promotion_posted_at`
+- `get_lifecycle_stage` is lighter; useful if `get_pick` returns a large `meta`
+
+### Step 3: Settlement Records
+
+Call `get_settlement_records` (unit-talk-state):
+
+```
+Tool: get_settlement_records
+Input: { "pick_id": "<pick-uuid>", "limit": 5 }
+```
+
+Returns all settlement attempts for this pick. Key fields per record:
+
+| Field               | Meaning                                    |
+| ------------------- | ------------------------------------------ |
+| `settlement_result` | `win` \| `loss` \| `push` \| null          |
+| `settlement_status` | `pending` \| `settled` \| ...              |
+| `settled_at`        | Timestamp of settlement                    |
+| `provider`          | Which provider settled this (e.g. `sgov3`) |
+| `raw_result`        | Raw provider payload                       |
+
+Multiple records = multiple settlement attempts. Most recent is authoritative.
+
+### Step 4: Report
+
+```markdown
+## Pick Trace — <pick-uuid>
+
+**Traced at**: <queried_at> **Stage**: <derived_stage> **Bet Slip**:
+<bet_slip_id> | **Leg**: <leg_index>
+
+### Lifecycle Fields
+
+| Field              | Value   |
+| ------------------ | ------- |
+| status             | <value> |
+| promotion_status   | <value> |
+| promotion_band     | <value> |
+| posted_to_discord  | <value> |
+| discord_message_id | <value> |
+| settlement_status  | <value> |
+| settlement_result  | <value> |
+| settlement_frozen  | <value> |
+
+### Timeline
+
+- created_at: <value>
+- placed_at: <value>
+- promotion_queued_at: <value>
+- promotion_posted_at: <value>
+- settled_at: <value>
+
+### Block / Failure Reason
+
+blocked_reason: <value or none> failed_reason: <value or none>
+
+### Settlement Records (<total> records)
+
+| #   | Result        | Status  | Provider | settled_at  |
+| --- | ------------- | ------- | -------- | ----------- |
+| 1   | win/loss/push | settled | sgov3    | <timestamp> |
+
+### Diagnosis
+
+<one-line diagnosis based on derived_stage and fields>
+```
+
+## Common Diagnoses
+
+| `derived_stage` | Likely Cause                  | Next Step                                           |
+| --------------- | ----------------------------- | --------------------------------------------------- |
+| `SUBMITTED`     | Not yet graded                | Check GradingAgent health via `/pipeline-health`    |
+| `QUEUED`        | Graded, waiting for promotion | Check DiscordPromotionAgent heartbeat               |
+| `POSTED`        | Correctly posted              | No action — confirm discord_message_id is valid     |
+| `BLOCKED`       | See `blocked_reason`          | Operator must review and unblock                    |
+| `FAILED`        | See `failed_reason`           | Investigate failure; use operator_override to retry |
+| `SETTLED`       | Settlement recorded           | Verify result matches expectations                  |
+| `DISPUTED`      | Settlement conflict           | Escalate to manual review                           |
+| `VOID`          | Pick voided                   | Expected — no further action                        |
+
+## Relevant Repo Paths
+
+| Path                                                 | Role                                                        |
+| ---------------------------------------------------- | ----------------------------------------------------------- |
+| `packages/mcp-state/src/tools/index.ts`              | `get_pick`, `get_lifecycle_stage`, `get_settlement_records` |
+| `packages/mcp-state/src/adapters/index.ts`           | `deriveStage` — parity with canonical                       |
+| `apps/api/src/lib/lifecycle/transition-validator.ts` | Canonical `deriveLifecycleStage`                            |
+| `apps/api/src/agents/DiscordPromotionAgent/`         | Posting agent — source of BLOCKED/FAILED                    |
+| `apps/api/src/agents/SettlementAgent/`               | Settlement source                                           |
+
+## Expected Output
+
+- Single pick lifecycle trace with all fields
+- Settlement record history
+- One-line diagnosis and recommended next action

--- a/.claude/skills/pipeline-health.md
+++ b/.claude/skills/pipeline-health.md
@@ -1,0 +1,166 @@
+# Skill: Pipeline Health
+
+## Purpose
+
+Get a complete platform health snapshot in a single pass: agent heartbeat
+summary, bridge_outbox queue depth, SLO attainment, and overall platform status.
+Use this as the **first diagnostic** when anything in the pick pipeline looks
+wrong.
+
+## When to Use
+
+- Picks are not appearing in Discord as expected
+- On-call: initial triage before diving into agent-level detail
+- Routine health check before or after a high-volume posting window
+- When `GET /api/health/summary` returns DEGRADED or CRITICAL
+- Before executing any operator workflow that touches live data
+
+## Invocation
+
+```
+/pipeline-health
+```
+
+No arguments required. All data is fetched via MCP from live Supabase + API.
+
+## Procedure
+
+### Step 1: Combined Pipeline Status
+
+Call `get_pipeline_status` (unit-talk-ops):
+
+```
+Tool: get_pipeline_status
+Input: {}
+```
+
+Key fields in response:
+
+| Field                           | Meaning                                           |
+| ------------------------------- | ------------------------------------------------- |
+| `agents.total`                  | Total agents tracked in `agent_health`            |
+| `agents.healthy`                | Heartbeat within threshold (default 5 min)        |
+| `agents.stale`                  | Heartbeat older than threshold                    |
+| `agents.missing`                | Never reported or inactive                        |
+| `outbox.pending`                | bridge_outbox records not yet picked up           |
+| `outbox.failed`                 | bridge_outbox records that errored                |
+| `outbox.oldest_pending_minutes` | Age of oldest pending record (null = queue empty) |
+| `outbox.stale_alert`            | `true` when picks are backed up or stalled        |
+| `queried_at`                    | Timestamp of this snapshot                        |
+
+**Alert thresholds:**
+
+- `outbox.pending > 20` → warning
+- `outbox.pending > 100` → critical
+- `agents.stale > 0` → investigate heartbeat
+- `agents.missing > 0` → agent may be down
+
+### Step 2: Platform Health Summary
+
+Call `get_platform_health` (unit-talk-ops):
+
+```
+Tool: get_platform_health
+Input: {}
+```
+
+Key fields:
+
+| Field              | Meaning                                              |
+| ------------------ | ---------------------------------------------------- |
+| `platform_status`  | `HEALTHY` \| `DEGRADED` \| `CRITICAL`                |
+| `subsystems[]`     | Per-subsystem `status`: `UP` \| `DEGRADED` \| `DOWN` |
+| `slo_breaches`     | Count of SLOs currently in BREACH                    |
+| `slo_warns`        | Count of SLOs in WARN state                          |
+| `alert_count`      | Total active alerts                                  |
+| `high_alert_count` | High-severity alerts                                 |
+| `autopilot_mode`   | Current autopilot setting                            |
+
+Focus on any `subsystems` with `status !== 'UP'` and report their `notes`.
+
+### Step 3: SLO Attainment (requires OPERATOR_TOKEN)
+
+Call `get_slo_status` (unit-talk-ops):
+
+```
+Tool: get_slo_status
+Input: {}
+```
+
+Key fields:
+
+| Field               | Meaning                        |
+| ------------------- | ------------------------------ |
+| `window_days`       | Attainment window (7d default) |
+| `slos[].name`       | SLO name                       |
+| `slos[].target`     | Target attainment (0–1)        |
+| `slos[].attainment` | Actual attainment (0–1)        |
+| `slos[].status`     | `OK` \| `WARN` \| `BREACH`     |
+| `breach_count`      | Number of breaching SLOs       |
+| `warn_count`        | Number of warning SLOs         |
+
+If OPERATOR_TOKEN is not set, skip this step and note it.
+
+### Step 4: Report
+
+Synthesize a single status block:
+
+```markdown
+## Pipeline Health — <queried_at>
+
+**Platform**: HEALTHY | DEGRADED | CRITICAL **Autopilot**: <autopilot_mode>
+
+### Agents
+
+- Total: X | Healthy: X | Stale: X | Missing: X
+
+### Outbox (bridge_outbox)
+
+- Pending: X | Failed: X | Oldest pending: X min | Stale alert: yes/no
+
+### Subsystems
+
+| Subsystem | Status           | Notes   |
+| --------- | ---------------- | ------- |
+| <name>    | UP/DEGRADED/DOWN | <notes> |
+
+### SLOs (<window_days>d window)
+
+| SLO         | Target   | Actual | Status         |
+| ----------- | -------- | ------ | -------------- |
+| <name>      | X%       | X%     | OK/WARN/BREACH |
+| Breaches: X | Warns: X |
+
+### Verdict
+
+✅ HEALTHY — no action required ⚠️ DEGRADED — <specific issue to investigate> ❌
+CRITICAL — <escalate immediately>
+```
+
+## Decision Tree
+
+| Condition                    | Next Step                                         |
+| ---------------------------- | ------------------------------------------------- |
+| `agents.stale > 0`           | Run `get_agent_health` for full heartbeat detail  |
+| `outbox.stale_alert = true`  | Check BridgeWorker logs; consider replay workflow |
+| `slo_breaches > 0`           | Run `/slo-report` for full SLO breakdown          |
+| Any subsystem `DOWN`         | Check agent logs for that subsystem               |
+| `platform_status = CRITICAL` | Page on-call; do not run operator workflows       |
+
+## Relevant Repo Paths
+
+| Path                                  | Role                                                           |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `packages/mcp-ops/src/tools/index.ts` | `get_pipeline_status`, `get_platform_health`, `get_slo_status` |
+| `apps/api/src/routes/health.ts`       | `GET /api/health/summary` (backing endpoint)                   |
+| `apps/api/src/routes/slo.ts`          | `GET /api/slo/status` (backing endpoint)                       |
+| `apps/api/src/lib/workflow-registry/` | Operator workflows for remediation                             |
+| `docs/ops/ON_CALL_RUNBOOK.md`         | Incident response scenarios                                    |
+
+## Expected Output
+
+- One-screen platform health snapshot
+- Agent heartbeat counts
+- Outbox queue depth with stale alert flag
+- Per-SLO attainment table (if OPERATOR_TOKEN available)
+- Verdict and next-step recommendation

--- a/.claude/skills/slo-report.md
+++ b/.claude/skills/slo-report.md
@@ -1,0 +1,149 @@
+# Skill: SLO Report
+
+## Purpose
+
+Generate a focused SLO attainment report: per-SLO status, breach/warn counts,
+and platform health context. Use this to understand whether the platform is
+meeting its service level objectives and which SLOs need remediation.
+
+## When to Use
+
+- Weekly or daily SLO review
+- After an incident to assess SLO impact
+- When `get_platform_health` reports `slo_breaches > 0`
+- Before planning a remediation sprint
+- When the on-call runbook asks "what SLOs are affected?"
+
+## Invocation
+
+```
+/slo-report [--context]
+```
+
+`--context`: also runs `get_platform_health` to correlate SLO state with
+subsystem health. Recommended for incident response.
+
+**Requires**: `OPERATOR_TOKEN` env var set in `unit-talk-ops` MCP server. If
+OPERATOR_TOKEN is missing, `get_slo_status` will return an auth error.
+
+## Procedure
+
+### Step 1: SLO Attainment (requires OPERATOR_TOKEN)
+
+Call `get_slo_status` (unit-talk-ops):
+
+```
+Tool: get_slo_status
+Input: {}
+```
+
+Key fields:
+
+| Field               | Meaning                                |
+| ------------------- | -------------------------------------- |
+| `window_days`       | Attainment window in days (default: 7) |
+| `computed_at`       | Timestamp                              |
+| `slos[].id`         | SLO identifier                         |
+| `slos[].name`       | Human-readable SLO name                |
+| `slos[].target`     | Target attainment (0.0–1.0)            |
+| `slos[].attainment` | Actual attainment (0.0–1.0)            |
+| `slos[].status`     | `OK` \| `WARN` \| `BREACH`             |
+| `slos[].unit`       | Unit label (e.g. `%`, `ms`)            |
+| `breach_count`      | Number of SLOs in BREACH               |
+| `warn_count`        | Number of SLOs in WARN                 |
+
+**Canonical SLOs** (from `docs/ops/SLO_DEFINITIONS.md`):
+
+| SLO                   | Target                            |
+| --------------------- | --------------------------------- |
+| lifecycle_attainment  | 95% picks reach POSTED within SLA |
+| discord_posting       | 98% successful Discord deliveries |
+| grading_latency_p50   | p50 grading latency < 300s        |
+| settlement_attainment | 99.5% picks settled correctly     |
+
+### Step 2: Platform Health Context (if `--context`)
+
+Call `get_platform_health` (unit-talk-ops):
+
+```
+Tool: get_platform_health
+Input: {}
+```
+
+Use `platform_status`, `slo_breaches`, `slo_warns`, and `subsystems[]` to
+correlate: which subsystem health issues are driving SLO degradation?
+
+### Step 3: Compute Attainment Gap
+
+For each SLO with `status !== 'OK'`:
+
+```
+gap = target - attainment
+gap_pct = gap * 100
+```
+
+A gap > 5% (relative to target) warrants a dedicated investigation or sprint.
+
+### Step 4: Report
+
+```markdown
+## SLO Report — <window_days>d window ending <computed_at>
+
+**Platform Status**: HEALTHY | DEGRADED | CRITICAL (from get_platform_health)
+
+### SLO Attainment
+
+| SLO                   | Target | Actual | Gap   | Status         |
+| --------------------- | ------ | ------ | ----- | -------------- |
+| lifecycle_attainment  | 95.0%  | X.X%   | -X.X% | OK/WARN/BREACH |
+| discord_posting       | 98.0%  | X.X%   | -X.X% | OK/WARN/BREACH |
+| grading_latency_p50   | —      | Xms    | —     | OK/WARN/BREACH |
+| settlement_attainment | 99.5%  | X.X%   | -X.X% | OK/WARN/BREACH |
+
+**Summary**: X breach(es), X warn(s)
+
+### Subsystem Correlation (if --context)
+
+| Subsystem | Health Status | SLO Impact |
+| --------- | ------------- | ---------- |
+| <name>    | UP/DEGRADED   | <inferred> |
+
+### Verdict
+
+✅ ALL SLOs OK — no action required ⚠️ WARN — monitor <SLO name>; consider
+investigation sprint if sustained ❌ BREACH — escalate <SLO name>; check on-call
+runbook Scenario <N>
+```
+
+## Remediation References
+
+| SLO                     | Breach Runbook                                                  |
+| ----------------------- | --------------------------------------------------------------- |
+| `lifecycle_attainment`  | `ON_CALL_RUNBOOK.md` Scenario 3: Posting Failure                |
+| `discord_posting`       | `ON_CALL_RUNBOOK.md` Scenario 2: Discord Outage                 |
+| `grading_latency_p50`   | Check GradingAgent heartbeat; review RiskEngine circuit breaker |
+| `settlement_attainment` | `ON_CALL_RUNBOOK.md` Scenario 4: Settlement Failure             |
+
+For any BREACH:
+
+1. Run `/pipeline-health` to check agent and outbox state
+2. Run `/pick-trace <id>` on affected picks to find stuck stages
+3. Execute the relevant `get_operator_workflows` workflow if one exists
+
+## Relevant Repo Paths
+
+| Path                                                      | Role                                         |
+| --------------------------------------------------------- | -------------------------------------------- |
+| `packages/mcp-ops/src/tools/index.ts`                     | `get_slo_status`, `get_platform_health`      |
+| `apps/api/src/routes/slo.ts`                              | `GET /api/slo/status` — backing endpoint     |
+| `apps/api/src/routes/health.ts`                           | `GET /api/health/summary` — backing endpoint |
+| `apps/api/src/lib/platform/PlatformThresholdEvaluator.ts` | Alert threshold logic                        |
+| `docs/ops/SLO_DEFINITIONS.md`                             | Canonical SLO definitions                    |
+| `docs/ops/ON_CALL_RUNBOOK.md`                             | Incident response per scenario               |
+
+## Expected Output
+
+- Per-SLO attainment table with gap and status
+- Breach/warn count summary
+- Optional platform subsystem correlation
+- Verdict and remediation pointer


### PR DESCRIPTION
SPRINT-056-OBSERVABILITY-SKILLS — 4 new operator skills backed by the verified MCP layer.

## Skills Added

- `.claude/skills/pipeline-health.md` — `get_pipeline_status` + `get_platform_health` + `get_slo_status`
- `.claude/skills/pick-trace.md` — `get_pick` + `get_lifecycle_stage` + `get_settlement_records`
- `.claude/skills/slo-report.md` — `get_slo_status` + `get_platform_health`
- `.claude/skills/edge-check.md` — `compute_clv` + `compute_calibration`

No MCP tool changes. Only consumes verified MCP interfaces from SPRINT-055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)