### PR TITLE
feat(ai-os): AI OS Skill Wave 2 — agent-health, prompt-compose, discord-diagnose

### DIFF
--- a/.claude/skills/agent-health/SKILL.md
+++ b/.claude/skills/agent-health/SKILL.md
@@ -1,0 +1,326 @@
+# Skill: Agent Health
+
+## Purpose
+
+Answer "what is the health of the AI operating layer right now?" from the
+current repo state. Provides a structured operator-facing diagnostic of which AI
+OS components are operational, stale, partial, or missing. Read-only — this
+skill never modifies files.
+
+**Portability class:** Adapter-Based (pattern reusable; sources are Unit
+Talk-specific)
+
+## Invocation
+
+```
+/agent-health
+```
+
+Or with focus area:
+
+```
+/agent-health --focus skills
+/agent-health --focus docs
+/agent-health --focus workflow
+```
+
+**Modes:**
+
+- **(default)** Full operating-layer health summary
+- **`--focus skills`** Skills layer only — what's operational vs. missing
+- **`--focus docs`** AI docs alignment only — what's defined vs. operationalized
+- **`--focus workflow`** Workflow coverage only — rules, hooks, conventions
+
+---
+
+## When to Use
+
+Run `/agent-health` when:
+
+- Beginning a new work session and want orientation before choosing a sprint
+- After a sequence of AI OS enhancement changes (e.g., new skills added, docs
+  updated)
+- Preparing to run `/sprint-plan` and want a pre-planning health view
+- Something feels drifted but you can't pinpoint where
+- After a long gap between sessions
+- After the AI doc layer has changed materially (new planning docs, readiness
+  updates)
+
+**Relationship to other skills:**
+
+- `/system-status` answers "where does the _platform_ stand?" — subsystems,
+  phases, drift, sprint queue
+- `/agent-health` answers "where does the _AI operating layer_ stand?" — skills,
+  docs, workflow conventions, automation coverage
+- Run `/system-status` first if you need platform truth; run `/agent-health`
+  first if you need AI OS layer truth
+
+---
+
+## Sources (read in this exact order)
+
+| Order | Source                                                | What it answers                                         |
+| ----- | ----------------------------------------------------- | ------------------------------------------------------- |
+| 1     | `.claude/skills/` directory listing                   | Which skills exist as SKILL.md files                    |
+| 2     | `.claude/rules/` directory listing + rule files       | Workflow enforcement coverage                           |
+| 3     | `docs/ai/AI_ENHANCEMENT_REMAINING_WORK_MAP_v1.md`     | What AI OS work was planned and what's still unfinished |
+| 4     | `docs/ai/AI_BOOTSTRAP_READINESS_CHECKLIST_v1.md`      | Current readiness state per AI OS layer                 |
+| 5     | `docs/status/CURRENT_SYSTEM_STATUS.md`                | Platform status for cross-reference                     |
+| 6     | `docs/status/DRIFT_REPORT.md`                         | Any AI-layer drift items                                |
+| 7     | Most recent `out/sprints/*/SPRINT_CLOSEOUT_REPORT.md` | Last sprint — did it affect the AI layer?               |
+
+Optional sources (check if freshness is in question):
+
+- `docs/ai/AI_PORTABLE_CORE_INVENTORY_v1.md` — portability classification state
+- `docs/ai/AI_PROJECT_ADAPTER_UNIT_TALK_v1.md` — Unit Talk adapter state
+- `tools/claude-os/src/` directory listing — TypeScript automation tools
+  available
+
+---
+
+## Procedure
+
+### Step 1: Inventory the Skills Layer
+
+```bash
+ls .claude/skills/
+```
+
+For each directory found, check whether a `SKILL.md` exists:
+
+```bash
+ls .claude/skills/*/SKILL.md 2>/dev/null
+```
+
+Classify each skill as:
+
+| Status               | Meaning                                               |
+| -------------------- | ----------------------------------------------------- |
+| **OPERATIONAL**      | `SKILL.md` exists and is non-empty                    |
+| **EMPTY**            | Directory exists but no `SKILL.md` (placeholder only) |
+| **EXPECTED-MISSING** | In the Wave 2 plan or AI docs but not yet created     |
+
+Cross-reference against `AI_ENHANCEMENT_REMAINING_WORK_MAP_v1.md` and
+`AI_SKILL_WAVE_2_PLAN_v1.md` (if present) to identify skills that were planned
+but not yet built.
+
+### Step 2: Inventory the Rules Layer
+
+```bash
+ls .claude/rules/
+```
+
+Read the rule files and assess coverage of the core workflow spine:
+
+| Gate                      | Rule That Covers It                   | Status            |
+| ------------------------- | ------------------------------------- | ----------------- |
+| Phase flow enforcement    | `00-workflow.md`                      | Present / Missing |
+| Proof discipline          | `01-safety-and-proof.md`              | Present / Missing |
+| DB migration safety       | `02-db-migrations.md`                 | Present / Missing |
+| Single-writer enforcement | `03-single-writer-and-idempotency.md` | Present / Missing |
+| Testing/verification      | `04-testing-and-verification.md`      | Present / Missing |
+| Output format standards   | `05-output-formats.md`                | Present / Missing |
+| Linear MCP discipline     | `06-linear-mcp-discipline.md`         | Present / Missing |
+| Lane model                | `07-lane-model.md`                    | Present / Missing |
+
+### Step 3: Read the AI Enhancement Work Map
+
+```bash
+cat docs/ai/AI_ENHANCEMENT_REMAINING_WORK_MAP_v1.md
+```
+
+Extract:
+
+- What was listed as "remaining work" in the map
+- Which items are still marked as "not yet built" or "defined only"
+- Whether the work map is still current or has been superseded by actual
+  implementations
+
+### Step 4: Read the Bootstrap Readiness Checklist
+
+```bash
+cat docs/ai/AI_BOOTSTRAP_READINESS_CHECKLIST_v1.md
+```
+
+Extract the current readiness verdict for each layer:
+
+- helpers: Defined / Ready for implementation / Partially operational /
+  Operational
+- hooks: Defined / Ready for implementation / Partially operational /
+  Operational
+- skills: Defined / Ready for implementation / Partially operational /
+  Operational
+- portability: Defined / Needs ratification / Operational
+
+Note whether the checklist is stale (does not reflect skills built after it was
+written).
+
+### Step 5: Check for AI-Layer Drift Items
+
+```bash
+grep -i "ai\|claude\|skill\|helper\|hook\|agent" docs/status/DRIFT_REPORT.md
+```
+
+Flag any CRITICAL or HIGH drift items that affect the AI operating layer.
+
+### Step 6: Cross-Reference with Last Sprint
+
+Find most recent sprint closeout:
+
+```bash
+ls -t out/sprints/*/*/SPRINT_CLOSEOUT_REPORT.md 2>/dev/null | head -1
+```
+
+Read it. Determine whether the last sprint changed the AI layer and whether that
+change is reflected in the readiness checklist / work map.
+
+### Step 7: Assess Automation Tool Coverage
+
+```bash
+ls tools/claude-os/src/*.ts 2>/dev/null
+```
+
+Note which automation tools exist as TypeScript CLI utilities (these are the
+mechanical backend layer — distinct from interactive SKILL.md procedures). These
+cover the automation side; skills cover the interactive operator procedure side.
+
+### Step 8: Generate Output
+
+Use the output format below.
+
+---
+
+## Output Format
+
+```markdown
+# AI Operating Layer — Health Report
+
+**As of**: <YYYY-MM-DD> | **AI Layer Status**: HEALTHY | PARTIAL | DEGRADED |
+INCOMPLETE
+
+---
+
+## Skills Layer
+
+| Skill  | Status            | Notes                                       |
+| ------ | ----------------- | ------------------------------------------- |
+| <name> | OPERATIONAL       | <one-line note>                             |
+| <name> | EMPTY PLACEHOLDER | No SKILL.md — spec exists but not built     |
+| <name> | EXPECTED-MISSING  | Planned in Wave 2 / AI docs but not created |
+
+**Summary**: <N> operational, <N> empty placeholders, <N> expected-missing
+
+---
+
+## Rules / Workflow Enforcement Layer
+
+| Gate             | Status  | Covered By                           |
+| ---------------- | ------- | ------------------------------------ |
+| Phase flow       | PRESENT | .claude/rules/00-workflow.md         |
+| Proof discipline | PRESENT | .claude/rules/01-safety-and-proof.md |
+| ...              | ...     | ...                                  |
+
+**Summary**: <N>/8 core rules present
+
+---
+
+## AI Docs Alignment
+
+| Doc                                     | State                                         | Notes  |
+| --------------------------------------- | --------------------------------------------- | ------ |
+| AI_ENHANCEMENT_REMAINING_WORK_MAP_v1.md | Current / Stale                               | <note> |
+| AI_BOOTSTRAP_READINESS_CHECKLIST_v1.md  | Current / Stale                               | <note> |
+| AI_SKILL_WAVE_2_PLAN_v1.md              | Defined / Partially Operational / Operational | <note> |
+
+**Readiness per layer (from checklist):**
+
+- Skills: <Defined / Ready / Partial / Operational>
+- Helpers/Agents: <status>
+- Hooks/Automation: <status>
+- Portability: <status>
+
+---
+
+## Automation Tools (tools/claude-os/src/)
+
+<N> TypeScript CLI modules present:
+
+- <name>: <one-line purpose>
+- ...
+
+---
+
+## AI-Layer Drift Items
+
+<list from DRIFT_REPORT.md, or "None found">
+
+---
+
+## Gaps and Stale Areas
+
+1. <gap or stale area — one line each>
+2. ...
+
+---
+
+## Next Action
+
+<one-sentence highest-priority recommendation>
+
+**Follow-on:**
+
+- If skills are missing → run `/sprint-plan` targeting the missing skill sprint
+- If docs are stale → update `AI_BOOTSTRAP_READINESS_CHECKLIST_v1.md` after next
+  operationalization
+- If no gaps → proceed with `/sprint-plan` from queue
+```
+
+---
+
+## Failure Protocol
+
+| Failure                                                                       | Action                                                     |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `docs/ai/` directory missing                                                  | HALT — AI doc layer absent; cannot assess                  |
+| `.claude/skills/` directory missing                                           | HALT — skills layer absent                                 |
+| All AI docs stale (no recent sprint touching AI layer)                        | Flag as DEGRADED; recommend AI-layer reconciliation sprint |
+| Work map lists items as not-built but skills directory shows them operational | Flag discrepancy — work map needs update                   |
+| Bootstrap readiness checklist does not reflect current state                  | Note staleness; do not treat checklist as current truth    |
+
+---
+
+## Non-Goals
+
+This skill does NOT:
+
+- Check runtime health of agents, Discord, scoring, or the platform (use
+  `/system-status`)
+- Modify any AI docs, status docs, or rule files
+- Make decisions about what to implement next (use `/sprint-plan` for that)
+- Replace a full architecture audit (use the arch-audit skill when it exists)
+- Claim completeness for items it cannot directly verify in the repo
+
+---
+
+## Integration with Claude OS
+
+| This skill uses                                   | Purpose                                                          |
+| ------------------------------------------------- | ---------------------------------------------------------------- |
+| `/system-status`                                  | Platform-level complement — run before or after for full context |
+| `/sprint-plan`                                    | Natural follow-on if gaps are found                              |
+| `docs/ai/AI_ENHANCEMENT_REMAINING_WORK_MAP_v1.md` | Governing roadmap for AI OS work                                 |
+| `tools/claude-os/src/`                            | Automation tools that sit alongside skills                       |
+| `.claude/rules/00-workflow.md`                    | Workflow enforcement baseline                                    |
+
+---
+
+## Notes
+
+- This skill reads only — it never writes to docs, code, or Linear
+- Do not claim a skill is "operational" unless a non-empty `SKILL.md` exists
+- Do not claim a hook is "covered" unless a rule file, skill step, or automation
+  explicitly provides that coverage
+- The AI Bootstrap Readiness Checklist may be stale — cross-reference actual
+  skill files before trusting its readiness states
+- Prefer underclaiming to overclaiming: PARTIAL is safer than OPERATIONAL when
+  evidence is ambiguous

--- a/.claude/skills/discord-diagnose/SKILL.md
+++ b/.claude/skills/discord-diagnose/SKILL.md
@@ -1,0 +1,310 @@
+# Skill: Discord Diagnose
+
+## Purpose
+
+Structured diagnostic workflow for Unit Talk Discord delivery and workflow
+failures. Classifies the issue, identifies the likely failure layer, and routes
+to the correct next action — without claiming runtime visibility the operator
+does not actually have.
+
+**Portability class:** Unit Talk-Specific v1 (pattern may generalize to
+`delivery-diagnose` in a future adapter-based version)
+
+## Invocation
+
+```
+/discord-diagnose
+```
+
+With symptom hint:
+
+```
+/discord-diagnose --symptom "pick not posted to channel"
+/discord-diagnose --symptom "wrong channel"
+/discord-diagnose --symptom "embed missing fields"
+```
+
+---
+
+## When to Use
+
+Run `/discord-diagnose` when:
+
+- A pick post did not appear in Discord when expected
+- A message posted to the wrong channel or thread
+- An embed is malformed, missing fields, or incomplete
+- A Discord command flow behaves unexpectedly
+- A role-gated experience doesn't match expectations
+- Onboarding DMs did not fire or fired incorrectly
+- Alerts or recap messages failed to deliver
+- The symptom appears Discord-related but the actual root cause is uncertain
+- You're about to start an unstructured Discord debug session — use this first
+
+**Do not use** for general platform issues unrelated to Discord delivery.
+
+---
+
+## Required Inputs (gather before starting)
+
+| Input                 | What it is                                                                          |
+| --------------------- | ----------------------------------------------------------------------------------- |
+| Expected behavior     | What should have happened                                                           |
+| Actual behavior       | What actually happened (or didn't)                                                  |
+| Workflow context      | Which workflow/agent/feature triggered it (posting, recap, alert, onboarding, etc.) |
+| Channel/route context | Target channel, thread, DM, or command                                              |
+| Timing                | When did this happen / when was it last working                                     |
+
+---
+
+## Optional Inputs
+
+- Discord channel IDs
+- Message type or slash command name
+- Screenshots or embed screenshots
+- Related pick ID, bet slip ID, or workflow identifier
+- Recent deployment or sprint that may have changed related code
+- Any error logs or output from the Discord bot process
+
+---
+
+## Failure Class Reference
+
+Before starting diagnosis, identify which failure class best fits the symptom:
+
+| Class                    | Description                                          | Example Symptoms                          |
+| ------------------------ | ---------------------------------------------------- | ----------------------------------------- |
+| **ROUTING**              | Message sent to wrong destination                    | Posted to wrong channel, wrong thread     |
+| **PERMISSION**           | Bot lacks required access                            | Embed rejected, message blocked, 403      |
+| **UPSTREAM_WORKFLOW**    | Discord symptom caused by API/agent failure upstream | Pick never reached posting stage          |
+| **CONTENT_GENERATION**   | Embed or message content is malformed                | Missing fields, null values, wrong format |
+| **ENV_MISMATCH**         | Dev/staging/prod config divergence                   | Works locally, fails in prod              |
+| **STALE_STATE**          | Cached config, bot not restarted after change        | Old channel IDs, outdated role mappings   |
+| **INCOMPLETE_WIRING**    | Feature was scaffolded but not fully connected       | Trigger exists but handler not wired      |
+| **EXPECTATION_MISMATCH** | Behavior is correct per code, expectation was wrong  | Feature intentionally works this way      |
+
+---
+
+## Procedure
+
+### Step 1: Classify the Symptom
+
+Based on the inputs gathered, identify the most likely failure class from the
+reference table above. Assign:
+
+- **Primary class:** most likely
+- **Secondary class:** if unclear, the second most likely
+- **Confidence:** HIGH / MEDIUM / LOW
+
+### Step 2: Inspect the Promotion / Posting Pipeline
+
+For posting failures (pick not appearing in Discord), trace the posting path:
+
+```bash
+# Check unified_picks for the relevant pick
+# Key fields to inspect:
+# - lifecycle_stage: should be 'promoted' or 'posted'
+# - posted_to_discord: should be true if posted
+# - posting_channel_id: which channel was targeted
+# - promotion_band: must not be null (null = never posted)
+# - pick_origin: capper / system / null (determines which posting path)
+
+# If pick_origin=capper → processCapperPicks() path
+# If meta.system_approved=true → processSystemPicks() path
+# If promotion_band=HARD and pick_origin IS NULL → processLegacyPicks() path
+```
+
+**Known failure patterns to check:**
+
+- `promotion_band = NULL` → pick reached grading but never got a promotion band
+  assigned → see SPRINT-DISCORD-WORKER-HEALTH-RESTORE fix (GradingAgent.ts line
+  ~972: must return `result.promotionBand || 'HARD'`)
+- `lifecycle_stage != 'promoted'` → pick did not pass promotion criteria
+- `posted_to_discord = false` + correct stage → Discord posting agent may not
+  have picked it up
+
+### Step 3: Check Discord Bot Health
+
+For any Discord failure, confirm bot is healthy:
+
+```bash
+# Check agent health table or health endpoint
+# Look for discord_api and discord_gateway health rows
+# discord_gateway intents must NOT include GuildPresences (removed in SPRINT-DISCORD-GATEWAY-INTENTS-ENABLEMENT)
+# Expected health: discord_api = HEALTHY, discord_gateway = CONNECTED
+```
+
+If the bot is showing unhealthy or disconnected, **routing or content issues are
+secondary** — fix bot health first.
+
+### Step 4: Check Channel Routing Configuration
+
+For wrong-channel failures:
+
+```bash
+# Inspect the Discord channel routing configuration
+# Channel IDs are configured in environment or database config
+# Check:
+#   - DISCORD_CHANNEL_ID env vars
+#   - Any channel routing tables or config files
+#   - Whether the feature uses hardcoded IDs vs dynamic lookup
+```
+
+**Common cause:** Dev/staging channel IDs in a production deployment
+(ENV_MISMATCH).
+
+### Step 5: Check Permissions
+
+For message-blocked or embed-rejected failures:
+
+- Confirm bot has `Send Messages` permission in the target channel
+- Confirm bot has `Embed Links` permission (required for rich embeds)
+- Confirm bot role is not excluded from the channel's role permissions
+- For DMs: confirm the user has DMs from server members enabled
+
+### Step 6: Trace the Upstream Workflow
+
+For failures where the pick/message never reached Discord:
+
+```bash
+# Inspect the workflow registry for the relevant workflow
+# Check: apps/api/src/lib/workflows/ or the WorkflowRegistry
+# GET /ops/workflows — lists all registered workflows and their states
+# GET /ops/workflows/<name> — details for a specific workflow
+```
+
+Determine whether the trigger event fired, whether the agent received it, and
+whether it reached the Discord posting stage.
+
+### Step 7: Check for Incomplete Wiring
+
+For features that were recently added but are not working:
+
+- Check that the Discord handler file is registered (not just scaffolded)
+- Check that the event listener or command handler is exported and imported in
+  the main bot index
+- Check that the slash command is registered with Discord's API (may need
+  re-registration after change)
+
+```bash
+# Check discord-bot/src/commands/ or handlers/ for the relevant handler
+# Verify it's imported in the main index or command loader
+```
+
+### Step 8: Generate Diagnosis Output
+
+Use the format below.
+
+---
+
+## Output Format
+
+```markdown
+# Discord Diagnose — <symptom summary>
+
+**Date**: <YYYY-MM-DD> **Symptom**: <one-line description> **Primary Class**:
+<ROUTING | PERMISSION | UPSTREAM_WORKFLOW | CONTENT_GENERATION | ENV_MISMATCH |
+STALE_STATE | INCOMPLETE_WIRING | EXPECTATION_MISMATCH> **Secondary Class**:
+<class or N/A> **Confidence**: HIGH | MEDIUM | LOW
+
+---
+
+## Failure Analysis
+
+<2-4 sentences: what the evidence points to, what layer is most likely
+responsible, and why>
+
+---
+
+## Priority Checks
+
+1. <Most important thing to check — specific query, endpoint, or file>
+2. <Second check>
+3. <Third check>
+
+---
+
+## Likely Owner / Next Path
+
+- [ ] <Action 1 — e.g., "Inspect unified_picks.promotion_band for affected
+      picks">
+- [ ] <Action 2>
+- [ ] <Action 3 — e.g., "Run /prompt-compose if code fix is needed">
+
+---
+
+## What This Is NOT
+
+<One sentence noting what this diagnosis explicitly rules out or cannot assess
+without more evidence>
+```
+
+---
+
+## Failure Protocol
+
+| Failure                            | Action                                                              |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| Cannot determine expected behavior | Ask operator — do not diagnose without it                           |
+| Bot health is unhealthy            | Diagnose bot health first; Discord-level diagnosis is secondary     |
+| Symptom is not Discord-related     | STOP — redirect to `/system-status` or `/incident-triage`           |
+| Cannot access relevant pick data   | Note the gap; produce best available diagnosis with explicit caveat |
+| Multiple classes equally plausible | Report both; recommend starting with the more verifiable one        |
+
+---
+
+## Non-Goals
+
+This skill does NOT:
+
+- Directly mutate Discord state, channel configs, or bot settings
+- Claim runtime visibility it does not actually have — if a check requires live
+  DB access, say so explicitly
+- Replace end-to-end integration testing
+- Diagnose non-Discord issues (platform health, phase blockers, scoring
+  problems)
+- Substitute for actual logs when logs are required for certainty
+
+---
+
+## Known Unit Talk Discord Architecture Reference
+
+Key concepts to keep in mind during diagnosis:
+
+| Component         | Location                        | Notes                                   |
+| ----------------- | ------------------------------- | --------------------------------------- |
+| Discord bot       | `apps/discord-bot/`             | Main bot process                        |
+| Posting agent     | `apps/api/src/`                 | DiscordPromotionAgent or equivalent     |
+| Posting paths     | 3 paths: capper, system, legacy | Pick origin determines path             |
+| Promotion band    | `unified_picks.promotion_band`  | NULL = never promoted                   |
+| Gateway intents   | `apps/discord-bot/`             | GuildPresences must NOT be included     |
+| Channel routing   | Environment config              | Check DISCORD\_\* env vars              |
+| Workflow registry | `apps/api/src/lib/workflows/`   | 18 registered workflows in 6 categories |
+| Health rows       | `agent_health` table            | discord_api + discord_gateway rows      |
+
+---
+
+## Integration with Claude OS
+
+| This skill uses                        | Purpose                                                      |
+| -------------------------------------- | ------------------------------------------------------------ |
+| `/system-status`                       | Check platform health before assuming Discord-specific cause |
+| `/prompt-compose`                      | If fix path is identified — compose implementation prompt    |
+| `docs/status/CURRENT_SYSTEM_STATUS.md` | Discord-related subsystem rows                               |
+| `docs/status/DRIFT_REPORT.md`          | Any active Discord drift items                               |
+| `apps/discord-bot/`                    | Bot source for wiring checks                                 |
+| `apps/api/src/`                        | Upstream agent / workflow source                             |
+
+---
+
+## Notes
+
+- Discord symptoms frequently have upstream causes — trace the full promotion
+  path before assuming a Discord config issue
+- Null `promotion_band` has been a persistent failure mode — always check this
+  for posting failures
+- Bot gateway intents were tightened in
+  SPRINT-DISCORD-GATEWAY-INTENTS-ENABLEMENT — do not re-add GuildPresences
+- If bot was recently redeployed, slash commands may need re-registration with
+  Discord API
+- This skill is Unit Talk-specific v1; a future `delivery-diagnose` adapter
+  could generalize the pattern

--- a/.claude/skills/prompt-compose/SKILL.md
+++ b/.claude/skills/prompt-compose/SKILL.md
@@ -1,0 +1,291 @@
+# Skill: Prompt Compose
+
+## Purpose
+
+Convert an approved sprint direction or approved architecture decision into a
+Claude-ready implementation prompt using the governed handoff template. Enforces
+that all required fields — scope, constraints, canonical sources, acceptance
+criteria, proof expectations — are present before handing off to Claude Code.
+
+**Portability class:** Portable Core (template and procedure are fully reusable
+across projects)
+
+## Invocation
+
+```
+/prompt-compose
+```
+
+Or with a sprint name hint:
+
+```
+/prompt-compose --sprint <SPRINT-NAME>
+```
+
+---
+
+## When to Use
+
+Run `/prompt-compose` when:
+
+- Architecture direction has been reviewed and approved
+- A sprint was selected via `/sprint-plan` and you're ready to hand it to Claude
+  Code
+- A remediation path from an audit or incident was approved and needs exact
+  implementation guardrails
+- A previous implementation attempt drifted or produced rework — the prompt was
+  underspecified
+
+**Critical distinction:** `/sprint-plan` selects _which_ sprint to run and
+generates a rationale. `/prompt-compose` turns the _approved_ direction into an
+implementation-ready prompt that Claude Code can execute without ambiguity.
+
+**Do not skip this step.** Underdetermined prompts are the primary cause of
+implementation drift and rework.
+
+---
+
+## Required Inputs (operator must confirm all)
+
+Before generating the prompt, the operator must have ready:
+
+| Input                                       | Source                                                                   | Required?    |
+| ------------------------------------------- | ------------------------------------------------------------------------ | ------------ |
+| Approved sprint name / objective            | `/sprint-plan` output or operator decision                               | **Required** |
+| Scope: what files/subsystems are in scope   | Sprint plan tasks or architecture decision                               | **Required** |
+| Non-goals: what must NOT be touched         | Sprint plan or architecture review                                       | **Required** |
+| Source of truth: canonical docs or patterns | Codebase + docs/                                                         | **Required** |
+| Constraints / invariants                    | `CLAUDE_EXECUTION_CONTRACT.md`, `docs/SYSTEM_INVARIANTS.md`, `CLAUDE.md` | **Required** |
+| Acceptance criteria                         | Sprint plan success criteria                                             | **Required** |
+| Verification steps                          | Known test commands, gate commands                                       | **Required** |
+| Output format                               | What artifacts are expected                                              | **Required** |
+
+---
+
+## Optional Inputs
+
+- Prior failed attempt summary (if this is a retry)
+- Known risk areas or gotchas
+- Related recent sprint closeout for context
+- Linear issue ID for reference
+- LLM routing decision (from `sprint-plan` output)
+
+---
+
+## Procedure
+
+### Step 1: Confirm Approved Direction Exists
+
+Before composing, verify that the sprint or architecture direction being handed
+off has been reviewed. Do not compose a prompt for an unreviewed idea.
+
+Ask:
+
+- "Has this sprint direction been selected via `/sprint-plan` or explicitly
+  approved by the operator?"
+- "Is the scope well-defined enough to bound Claude Code's execution?"
+- "Are the non-goals explicit?"
+
+If any of these are unclear, **STOP** and resolve before composing.
+
+### Step 2: Read Canonical Sources
+
+Read the documents that the implementation must respect:
+
+```bash
+# Always read these for any sprint prompt
+cat docs/status/CURRENT_SYSTEM_STATUS.md    # current system state
+cat docs/status/PHASE_STATUS.md             # current phase
+cat CLAUDE_EXECUTION_CONTRACT.md            # non-negotiable invariants
+```
+
+Read additional sources depending on scope:
+
+```bash
+# If touching unified_picks or lifecycle
+cat docs/contracts/PICK_LIFECYCLE_CONTRACT.md
+cat .claude/rules/03-single-writer-and-idempotency.md
+
+# If touching DB migrations
+cat .claude/rules/02-db-migrations.md
+
+# If touching Command Center
+# Check existing CC auth pattern and proxy conventions
+
+# If touching agents or API behavior
+cat docs/SYSTEM_INVARIANTS.md
+```
+
+### Step 3: Extract Current Phase and Layer Context
+
+From `PHASE_STATUS.md`, confirm:
+
+- Which layer/phase this sprint belongs to
+- Whether this phase has active blockers
+
+From `NEXT_5_SPRINTS.md` (if available), confirm:
+
+- The sprint is queued or approved
+- Dependencies are met
+
+### Step 4: Fill the Handoff Template
+
+Use the template from `docs/ai/CHATGPT_TO_CLAUDE_HANDOFF_TEMPLATE_v1.md`.
+
+The filled template is the prompt. Every field is required. A field left blank
+or vague is a known ambiguity risk.
+
+```markdown
+## Handoff: <SPRINT-NAME>
+
+**Objective** <One sentence: what must be true when this is done?>
+
+**Why It Matters** <One to two sentences: what breaks or degrades if this is not
+done? What does this unlock?>
+
+**Scope** <Explicit list of files, subsystems, or behaviors that are in scope.
+Be specific. Name paths where possible.>
+
+**Non-Goals**
+<Explicit list of what must NOT be touched. Name things that may seem related
+but are out of scope.>
+
+**Source of Truth** <Canonical references Claude Code must consult before
+writing code. Name files, contracts, patterns, or directories explicitly.>
+
+**Constraints / Invariants** <Hard rules that cannot be violated. Typically
+from:
+
+- CLAUDE_EXECUTION_CONTRACT.md
+- docs/SYSTEM_INVARIANTS.md
+- Single-writer policy (CLAUDE.md §4)
+- Migration rules (.claude/rules/02-db-migrations.md)
+- Phase/roadmap sequencing>
+
+**Implementation Tasks** <Numbered, ordered list. Each task completable and
+verifiable independently.>
+
+1.
+2.
+3.
+
+**Verification Steps** <Specific commands to confirm correct implementation.>
+
+- [ ] `npm run type-check` passes
+- [ ] `npm run test` passes
+- [ ] `npm run lifecycle:single-writer -- --strict` passes (if unified_picks
+      touched)
+- [ ] <task-specific behavioral check>
+
+**Output Format** <What must be delivered: code diffs, proof artifacts, test
+file, specific doc. Include path: `out/sprints/<SPRINT>/<DATE>/`.>
+
+**Success Criteria** <Observable, unambiguous conditions that define "done."
+Each verifiable without human interpretation.>
+
+- <Criterion 1>
+- <Criterion 2>
+```
+
+### Step 5: Quality-Check the Filled Prompt
+
+Before delivering, verify:
+
+- [ ] Objective is a single unambiguous sentence
+- [ ] Scope names specific files or subsystems (not "the relevant area")
+- [ ] Non-goals explicitly exclude the most common scope-creep candidates
+- [ ] Source of Truth names at least one specific file path or contract
+- [ ] Constraints include any lifecycle, single-writer, or migration rules that
+      apply
+- [ ] Tasks are ordered and independently verifiable
+- [ ] Verification steps include at minimum: type-check + tests
+- [ ] Success criteria are observable without interpretation
+
+If any field fails this check, revise before delivering.
+
+### Step 6: Add Governance Reminders
+
+Append to the prompt:
+
+```markdown
+---
+
+**Governance Reminders**
+
+- Run `pnpm session:baseline` before starting
+- Run `pnpm pre-sprint-check` to confirm baseline freshness
+- Proof artifacts go in `out/sprints/<SPRINT>/<DATE>/`
+- Sprint is NOT complete until: committed + tagged + merged to main
+- After merge: run `/status-sync <SPRINT-NAME>`
+- Linear issue: <UNI-N or "create before starting">
+- Layer/Phase: <Layer N / Phase M — Name>
+```
+
+### Step 7: Deliver the Prompt
+
+Output the complete filled prompt. The operator pastes it into a new Claude Code
+session to begin implementation.
+
+---
+
+## Output Format
+
+The skill outputs one artifact: a complete, ready-to-paste implementation
+prompt. It should include:
+
+1. The filled handoff template (all fields)
+2. The governance reminders block
+
+No other commentary is needed unless the operator asks for rationale.
+
+---
+
+## Failure Protocol
+
+| Failure                           | Action                                                                 |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| Approved direction does not exist | STOP — run `/sprint-plan` first                                        |
+| Scope cannot be bounded           | STOP — operator must define scope before composing                     |
+| Canonical docs unavailable        | Note specifically which docs are missing; compose with explicit caveat |
+| Non-goals not definable           | STOP — scope is still ambiguous                                        |
+| Sprint prerequisites not met      | Flag in prompt; do not suppress                                        |
+
+---
+
+## Non-Goals
+
+This skill does NOT:
+
+- Decide which sprint to run (use `/sprint-plan`)
+- Approve architecture decisions (those must happen before this skill runs)
+- Execute implementation (the output is a prompt; Claude Code executes it)
+- Replace verification or proof requirements (those are downstream)
+- Work without a bounded approved direction
+
+---
+
+## Integration with Claude OS
+
+| This skill uses                                    | Purpose                                             |
+| -------------------------------------------------- | --------------------------------------------------- |
+| `docs/ai/CHATGPT_TO_CLAUDE_HANDOFF_TEMPLATE_v1.md` | Canonical template structure                        |
+| `docs/ai/AI_PREFLIGHT_CHECKLIST_v1.md`             | Pre-composition checklist                           |
+| `docs/ai/AI_TASK_ROUTING_MATRIX_v1.md`             | Confirms task routing before composing              |
+| `CLAUDE_EXECUTION_CONTRACT.md`                     | Non-negotiable constraint source                    |
+| `docs/SYSTEM_INVARIANTS.md`                        | System invariant constraint source                  |
+| `/sprint-plan`                                     | Natural predecessor — provides the approved sprint  |
+| `/status-sync`                                     | Natural successor — runs after the sprint completes |
+| `.claude/rules/00-workflow.md`                     | Workflow phase gate reference                       |
+
+---
+
+## Notes
+
+- This skill is the Prompt Composer Agent from the helper architecture docs,
+  implemented as an interactive skill procedure — not an autonomous agent
+- The output is only as good as the inputs: if the approved direction is vague,
+  the prompt will be vague. Do not compose under ambiguity.
+- A well-composed prompt eliminates the need for mid-implementation
+  clarification and reduces proof failures
+- See `docs/ai/CHATGPT_TO_CLAUDE_HANDOFF_TEMPLATE_v1.md` for the filled example
+  (SPRINT-054 replay endpoint) as a quality reference


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/agent-health/SKILL.md` — AI operating layer health review (Adapter-Based): inventories operational vs. missing skills, rules coverage, AI doc alignment, automation tooling
- Adds `.claude/skills/prompt-compose/SKILL.md` — governed interactive procedure for converting approved sprint direction into a Claude-ready implementation prompt (Portable Core); reuses `CHATGPT_TO_CLAUDE_HANDOFF_TEMPLATE_v1.md`
- Adds `.claude/skills/discord-diagnose/SKILL.md` — Unit Talk-specific diagnostic workflow for Discord delivery/promotion failures (Unit Talk-Specific v1); includes failure class taxonomy, promotion pipeline trace, bot health checks, wiring verification

These are the top 3 missing items from the AI OS gap audit. No hook infrastructure added, no existing skills duplicated.

## Test plan

- [ ] `/agent-health` invocation returns structured AI OS layer health report
- [ ] `/prompt-compose` halts if no approved sprint direction exists; outputs complete paste-ready prompt when all inputs are present
- [ ] `/discord-diagnose` classifies symptom by failure class and routes to correct check sequence
- [ ] No changes to production code, tests, or CI configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)