### PR TITLE
feat(command-center): workflow registry dashboard — SPRINT-060

### DIFF
--- a/apps/command-center/src/__tests__/workflows-routes.test.ts
+++ b/apps/command-center/src/__tests__/workflows-routes.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for ops/workflows proxy route.
+ * Sprint: SPRINT-060-LAYER3-PHASE11-CC-WORKFLOW-MANAGEMENT
+ *
+ * Covers:
+ *   1.  GET /api/ops/workflows → 401 when no auth
+ *   2.  GET /api/ops/workflows → proxies registry response
+ *   3.  GET /api/ops/workflows?category=health → passes category filter upstream
+ *   4.  GET /api/ops/workflows → returns 503 on upstream error
+ *   5.  GET /api/ops/workflows → forwards internal admin token to upstream
+ */
+
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Auth mock ─────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/auth', () => ({
+  requireOperatorIdentity: vi.fn(),
+  getOperatorIdentity: vi.fn(),
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { GET } from '@/app/api/ops/workflows/route';
+import { requireOperatorIdentity } from '@/lib/auth';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(path = '/api/ops/workflows', userId?: string): NextRequest {
+  const req = new NextRequest(`http://localhost${path}`);
+  if (userId) {
+    req.headers.set('x-user-id', userId);
+  }
+  return req;
+}
+
+const mockRequireOperatorIdentity = vi.mocked(requireOperatorIdentity);
+
+function setAuth(userId: string | null) {
+  if (userId) {
+    mockRequireOperatorIdentity.mockReturnValue({ userId, source: 'header' });
+  } else {
+    mockRequireOperatorIdentity.mockReturnValue(null);
+  }
+}
+
+const SAMPLE_REGISTRY = {
+  workflows: [
+    {
+      name: 'grade-picks',
+      displayName: 'Grade Picks',
+      description: 'Runs the grading pipeline for pending picks',
+      category: 'analysis',
+      scriptPath: 'scripts/grade-picks.ts',
+      riskLevel: 'low',
+      invocation: 'pnpm grade:picks',
+    },
+    {
+      name: 'settle-picks',
+      displayName: 'Settle Picks',
+      description: 'Settles picks against final scores',
+      category: 'settlement',
+      scriptPath: 'scripts/settle-picks.ts',
+      riskLevel: 'medium',
+      invocation: 'pnpm settle:picks',
+    },
+  ],
+  categories: ['analysis', 'settlement'],
+  counts: { analysis: 1, settlement: 1 },
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/ops/workflows', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when no operator identity', async () => {
+    setAuth(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('proxies registry response from upstream', async () => {
+    setAuth('op-1');
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(SAMPLE_REGISTRY), { status: 200 })
+    );
+
+    const res = await GET(makeRequest('/api/ops/workflows', 'op-1'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.workflows).toHaveLength(2);
+    expect(body.categories).toContain('analysis');
+    expect(body.workflows[0].name).toBe('grade-picks');
+  });
+
+  it('passes ?category= filter through to upstream URL', async () => {
+    setAuth('op-1');
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          workflows: [SAMPLE_REGISTRY.workflows[0]],
+          categories: ['analysis'],
+          counts: { analysis: 1 },
+        }),
+        { status: 200 }
+      )
+    );
+
+    await GET(makeRequest('/api/ops/workflows?category=analysis', 'op-1'));
+
+    const [calledUrl] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toContain('category=analysis');
+  });
+
+  it('returns 503 with empty registry on upstream error', async () => {
+    setAuth('op-1');
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const res = await GET(makeRequest('/api/ops/workflows', 'op-1'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.workflows).toHaveLength(0);
+    expect(body.categories).toHaveLength(0);
+    expect(body.error).toBeDefined();
+  });
+
+  it('forwards internal admin token to upstream', async () => {
+    setAuth('op-1');
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(SAMPLE_REGISTRY), { status: 200 })
+    );
+
+    await GET(makeRequest('/api/ops/workflows', 'op-1'));
+
+    const [, options] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const headers = options.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^Bearer /);
+  });
+});

--- a/apps/command-center/src/app/api/ops/workflows/route.ts
+++ b/apps/command-center/src/app/api/ops/workflows/route.ts
@@ -1,0 +1,61 @@
+/**
+ * WorkflowRegistry Proxy
+ * Sprint: SPRINT-060-LAYER3-PHASE11-CC-WORKFLOW-MANAGEMENT
+ *
+ * GET /api/ops/workflows
+ * Proxies to API service GET /ops/workflows.
+ * Returns the full WorkflowRegistry (18 entries, 6 categories).
+ * Supports optional ?category= filter passthrough.
+ *
+ * API side requires operatorAuth (JWT); CC forwards the internal admin token.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireOperatorIdentity } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const API_URL =
+  process.env.INTERNAL_API_URL || process.env.API_SERVICE_URL || 'http://localhost:3010';
+
+const ADMIN_TOKEN = process.env.INTERNAL_API_TOKEN || 'Bearer admin-internal';
+
+export async function GET(request: NextRequest) {
+  const identity = requireOperatorIdentity(request);
+  if (!identity) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const category = searchParams.get('category');
+
+  const upstreamUrl = category
+    ? `${API_URL}/ops/workflows?category=${encodeURIComponent(category)}`
+    : `${API_URL}/ops/workflows`;
+
+  try {
+    const authHeader = ADMIN_TOKEN.startsWith('Bearer ') ? ADMIN_TOKEN : `Bearer ${ADMIN_TOKEN}`;
+
+    const res = await fetch(upstreamUrl, {
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+      },
+      signal: AbortSignal.timeout(8000),
+    });
+
+    const json = await res.json();
+    return NextResponse.json(json, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        workflows: [],
+        categories: [],
+        counts: {},
+        error: err instanceof Error ? err.message : 'Upstream unavailable',
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/command-center/src/app/dashboard/workflows/page.tsx
+++ b/apps/command-center/src/app/dashboard/workflows/page.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+/**
+ * Workflow Registry Dashboard
+ * Sprint: SPRINT-060-LAYER3-PHASE11-CC-WORKFLOW-MANAGEMENT
+ * Layer: Layer 3 / Phase 11 — Workflow Optimization
+ *
+ * Surfaces the WorkflowRegistry (18 entries, 6 categories) from
+ *   GET /api/ops/workflows → API GET /ops/workflows
+ */
+
+import { Activity, GitBranch, RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import { PermissionGate } from '@/components/PermissionGate';
+import { Permission } from '@/lib/rbac';
+
+// ─── Local type definitions ────────────────────────────────────────────────────
+// Mirrors apps/api/src/lib/workflow-registry/types.ts — do not import from API
+
+type WorkflowCategory = 'analysis' | 'backfill' | 'feed' | 'health' | 'settlement' | 'ops';
+type WorkflowRiskLevel = 'low' | 'medium' | 'high';
+
+interface WorkflowParameter {
+  name: string;
+  description: string;
+  required: boolean;
+  type: 'string' | 'number' | 'boolean';
+  example?: string;
+}
+
+interface WorkflowEntry {
+  name: string;
+  displayName: string;
+  description: string;
+  category: WorkflowCategory;
+  scriptPath: string;
+  riskLevel: WorkflowRiskLevel;
+  invocation: string;
+  parameters?: WorkflowParameter[];
+  requiresDatabase?: boolean;
+}
+
+interface WorkflowsResponse {
+  workflows: WorkflowEntry[];
+  categories: WorkflowCategory[];
+  counts: Record<WorkflowCategory, number>;
+  error?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const RISK_BADGE: Record<WorkflowRiskLevel, { label: string; className: string }> = {
+  low: {
+    label: 'Low',
+    className: 'bg-emerald-500/10 text-emerald-600 border border-emerald-500/20',
+  },
+  medium: {
+    label: 'Medium',
+    className: 'bg-yellow-500/10 text-yellow-600 border border-yellow-500/20',
+  },
+  high: {
+    label: 'High',
+    className: 'bg-red-500/10 text-red-600 border border-red-500/20',
+  },
+};
+
+const CATEGORY_LABELS: Record<WorkflowCategory, string> = {
+  analysis: 'Analysis',
+  backfill: 'Backfill',
+  feed: 'Feed',
+  health: 'Health',
+  settlement: 'Settlement',
+  ops: 'Ops',
+};
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function RiskBadge({ level }: { level: WorkflowRiskLevel }) {
+  const { label, className } = RISK_BADGE[level];
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function WorkflowRow({ workflow }: { workflow: WorkflowEntry }) {
+  return (
+    <tr className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors">
+      <td className="py-3 px-4">
+        <div className="font-medium text-sm text-foreground">{workflow.displayName}</div>
+        <div className="text-xs text-muted-foreground mt-0.5">{workflow.name}</div>
+      </td>
+      <td className="py-3 px-4 text-sm text-muted-foreground max-w-xs">{workflow.description}</td>
+      <td className="py-3 px-4">
+        <RiskBadge level={workflow.riskLevel} />
+      </td>
+      <td className="py-3 px-4">
+        <code className="text-xs bg-muted rounded px-1.5 py-0.5 font-mono text-muted-foreground break-all">
+          {workflow.invocation}
+        </code>
+      </td>
+    </tr>
+  );
+}
+
+function CategorySection({
+  category,
+  workflows,
+}: {
+  category: WorkflowCategory;
+  workflows: WorkflowEntry[];
+}) {
+  if (workflows.length === 0) return null;
+  return (
+    <div className="mb-6">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2 flex items-center gap-2">
+        <GitBranch className="h-3.5 w-3.5" />
+        {CATEGORY_LABELS[category]}
+        <span className="text-xs font-normal text-muted-foreground/60">({workflows.length})</span>
+      </h3>
+      <div className="rounded-md border border-border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted/40">
+              <th className="text-left py-2 px-4 text-xs font-medium text-muted-foreground w-48">
+                Workflow
+              </th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-muted-foreground">
+                Description
+              </th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-muted-foreground w-20">
+                Risk
+              </th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-muted-foreground">
+                Invocation
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {workflows.map(w => (
+              <WorkflowRow key={w.name} workflow={w} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function WorkflowsPage() {
+  const [data, setData] = useState<WorkflowsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/ops/workflows');
+      const json: WorkflowsResponse = await res.json();
+      if (!res.ok || json.error) {
+        setError(json.error ?? `Error ${res.status}`);
+        setData(null);
+      } else {
+        setData(json);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load workflows');
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <PermissionGate
+      permission={Permission.VIEW_DASHBOARD}
+      fallback={
+        <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
+          <Activity className="h-8 w-8 mb-2" />
+          <p className="text-sm">Insufficient permissions to view workflows.</p>
+        </div>
+      }
+    >
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-foreground flex items-center gap-2">
+              <GitBranch className="h-6 w-6 text-primary" />
+              Workflow Registry
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Registered workflows across the Unit Talk platform
+            </p>
+          </div>
+          <button
+            onClick={() => void load()}
+            disabled={loading}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+        </div>
+
+        {/* Summary stats */}
+        {data && (
+          <div className="flex items-center gap-6 text-sm text-muted-foreground">
+            <span>
+              <span className="font-semibold text-foreground">{data.workflows.length}</span>{' '}
+              workflows
+            </span>
+            <span>
+              <span className="font-semibold text-foreground">{data.categories.length}</span>{' '}
+              categories
+            </span>
+          </div>
+        )}
+
+        {/* Loading */}
+        {loading && (
+          <div className="flex items-center justify-center h-40 text-muted-foreground">
+            <RefreshCw className="h-5 w-5 animate-spin mr-2" />
+            <span className="text-sm">Loading workflow registry…</span>
+          </div>
+        )}
+
+        {/* Error */}
+        {!loading && error && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-600">
+            <span className="font-medium">Failed to load workflows: </span>
+            {error}
+          </div>
+        )}
+
+        {/* Registry grouped by category */}
+        {!loading &&
+          data &&
+          data.categories.map(category => (
+            <CategorySection
+              key={category}
+              category={category}
+              workflows={data.workflows.filter(w => w.category === category)}
+            />
+          ))}
+      </div>
+    </PermissionGate>
+  );
+}

--- a/apps/command-center/src/components/layout/sidebar.tsx
+++ b/apps/command-center/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import {
   BarChart3,
   Bot,
   FileCheck,
+  GitBranch,
   Users,
   Zap,
   Target,
@@ -54,6 +55,7 @@ const NAV_SECTIONS: NavSection[] = [
       { name: 'PicksHQ', href: '/dashboard/picks', icon: Target },
       { name: 'Grading HQ', href: '/dashboard/grading', icon: Timer },
       { name: 'Replay', href: '/dashboard/replay', icon: RefreshCw },
+      { name: 'Workflows', href: '/dashboard/workflows', icon: GitBranch },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- **GET /api/ops/workflows** — new CC proxy route forwarding to `GET /ops/workflows` via `INTERNAL_API_TOKEN`; `dynamic = 'force-dynamic'`; `AbortSignal.timeout(8000)`; `?category=` filter passthrough; structured 503 fallback
- **`/dashboard/workflows`** — `'use client'` page rendering 18 workflows grouped by 6 categories (analysis/backfill/feed/health/settlement/ops) with displayName, description, risk badge, and invocation snippet; `PermissionGate(VIEW_DASHBOARD)`
- **Sidebar** — `GitBranch` icon added; "Workflows" nav entry added to Operations section after "Replay"
- **5 vitest tests** — 401 auth, proxy success, category filter, 503 upstream error, internal token forwarding

## Verification

- CC type-check: ✅ PASS (0 errors)
- CC build: ✅ PASS (`/dashboard/workflows` 14.3 kB in output)
- CC vitest: ✅ 78/78 (73 existing + 5 new)
- Lifecycle gate: ✅ PASS (1004 files, 0 violations)
- cc:no-mocks: ⚠️ pre-existing failure on `supabase.ts` (missing DEMO_MODE constant from SPRINT-RAW-PROPS-BURNDOWN-046); no mock data introduced by this sprint

## Sprint

**SPRINT-060-LAYER3-PHASE11-CC-WORKFLOW-MANAGEMENT**  
Layer 3 / Phase 11 — Workflow Optimization  
Depends on: SPRINT-052-LAYER3-PHASE11-OPERATOR-WORKFLOW-FOUNDATION ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)