### PR TITLE
docs(governance): sprint closeout SPRINT-061

### DIFF
--- a/governance/closeouts/SPRINT-061-LAYER3-PHASE10-CC-ALERT-DASHBOARD.md
+++ b/governance/closeouts/SPRINT-061-LAYER3-PHASE10-CC-ALERT-DASHBOARD.md
@@ -1,0 +1,26 @@
+# Sprint Closeout: SPRINT-061-LAYER3-PHASE10-CC-ALERT-DASHBOARD
+
+**Status**: COMPLETE **Merged**: 3603abc4 **PR**: #265 **Date**: 2026-03-16
+**Linear**: UNI-96 **Layer/Phase**: Layer 3 / Phase 10 — Command Center UX
+
+## Deliverables
+
+- GET /ops/alerts route (alertManager.getActiveAlerts, bySeverity meta)
+- CC proxy /api/alerts (force-dynamic, requireOperatorIdentity, 503 fallback)
+- Rewrote stale /api/alerts (was writing to api_alerts DB — forbidden for
+  read-only CC)
+- /dashboard/alerts page: grouped by severity critical→warning→info, empty state
+- Sidebar: Bell icon + "Alerts" nav item in Monitoring section
+- supabase.ts: DEMO_MODE constant (cc:no-mocks gate fix — unblocks all CC PRs)
+- 5 API vitest + 6 CC vitest — API: 1000/1000, CC: 84/84
+
+## Gates
+
+- type-check API: PASS
+- type-check CC: PASS
+- API vitest: 1000/1000
+- CC vitest: 84/84
+- cc:no-mocks: GATE PASSED
+- lifecycle:single-writer --strict: GATE PASSED
+- API build: PASS
+- CC build: PASS


### PR DESCRIPTION
Governance closeout marker for SPRINT-061-LAYER3-PHASE10-CC-ALERT-DASHBOARD. Triggers CI tag minting.